### PR TITLE
added support for JWK sets in organizations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ The server and client API is generated from the open-api spec:
 
 .. code-block:: shell
 
-    oapi-codegen -package api docs/_static/nuts-registry.yaml > api/generated.go
+    oapi-codegen -generate types,server,client -package api docs/_static/nuts-registry.yaml > api/generated.go
 
 Generating Mocks
 ****************

--- a/api/api.go
+++ b/api/api.go
@@ -23,13 +23,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-registry/pkg"
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 )
 
 // String converts an identifier to string

--- a/api/api.go
+++ b/api/api.go
@@ -161,8 +161,8 @@ func (apiResource ApiWrapper) SearchOrganizations(ctx echo.Context, params Searc
 
 	var (
 		searchResult []db.Organization
-		org 		 *db.Organization
-		err 		 error
+		org          *db.Organization
+		err          error
 	)
 
 	if params.Exact != nil && *params.Exact {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -108,6 +108,7 @@ var multiEndpoints = []db.Endpoint{
 	},
 }
 
+var key = map[string]interface{}{"kty": "EC"}
 var organizations = []db.Organization{
 	{
 		Identifier: db.Identifier("urn:nuts:system:value"),
@@ -116,6 +117,9 @@ var organizations = []db.Organization{
 	{
 		Identifier: db.Identifier("urn:nuts:hidden"),
 		Name:       "hidden",
+		Keys: 		[]interface{}{
+			key,
+		},
 	},
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -22,11 +22,12 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
+
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-registry/pkg"
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
 	"github.com/stretchr/testify/assert"
-	"net/url"
 
 	"net/http"
 	"net/http/httptest"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -117,7 +117,7 @@ var organizations = []db.Organization{
 	{
 		Identifier: db.Identifier("urn:nuts:hidden"),
 		Name:       "hidden",
-		Keys: 		[]interface{}{
+		Keys: []interface{}{
 			key,
 		},
 	},

--- a/api/client.go
+++ b/api/client.go
@@ -24,14 +24,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	core "github.com/nuts-foundation/nuts-go-core"
-	"github.com/nuts-foundation/nuts-registry/pkg/db"
-	"github.com/sirupsen/logrus"
 	"go/types"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/nuts-foundation/nuts-registry/pkg/db"
+	"github.com/sirupsen/logrus"
 )
 
 // HttpClient holds the server address and other basic settings for the http client

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -22,11 +22,12 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // RoundTripFunc

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -36,6 +36,17 @@ func (o Organization) fromDb(db db.Organization) Organization {
 	o.Name = db.Name
 	o.PublicKey = db.PublicKey
 	o.Endpoints = &e
+
+	if len(db.Keys) > 0 {
+		keys := make([]JWK, len(db.Keys))
+
+		for i, k := range db.Keys {
+			keys[i] = JWK{AdditionalProperties: k.(map[string]interface{})}
+		}
+
+		o.Keys = &keys
+	}
+
 	return o
 }
 
@@ -46,15 +57,24 @@ func (eo EndpointOrganization) fromDb(db db.EndpointOrganization) EndpointOrgani
 	return eo
 }
 
-func (a Organization) toDb() db.Organization {
+func (o Organization) toDb() db.Organization {
 	org := db.Organization{
-		Identifier: db.Identifier(a.Identifier),
-		Name:       a.Name,
-		PublicKey:  a.PublicKey,
+		Identifier: db.Identifier(o.Identifier),
+		Name:       o.Name,
+		PublicKey:  o.PublicKey,
 	}
 
-	if a.Endpoints != nil {
-		org.Endpoints = endpointsArrayToDb(*a.Endpoints)
+	if o.Keys != nil {
+		ks := *o.Keys
+		em := make([]interface{}, len(ks))
+		for i, k := range ks {
+			em[i] = k.AdditionalProperties
+		}
+		org.Keys = em
+	}
+
+	if o.Endpoints != nil {
+		org.Endpoints = endpointsArrayToDb(*o.Endpoints)
 	}
 
 	return org

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -37,15 +37,17 @@ func (o Organization) fromDb(db db.Organization) Organization {
 	o.PublicKey = db.PublicKey
 	o.Endpoints = &e
 
-	if len(db.Keys) > 0 {
-		keys := make([]JWK, len(db.Keys))
-
-		for i, k := range db.Keys {
-			keys[i] = JWK{AdditionalProperties: k.(map[string]interface{})}
-		}
-
-		o.Keys = &keys
+	if len(db.Keys) == 0 {
+		return o
 	}
+
+	keys := make([]JWK, len(db.Keys))
+
+	for i, k := range db.Keys {
+		keys[i] = JWK{AdditionalProperties: k.(map[string]interface{})}
+	}
+
+	o.Keys = &keys
 
 	return o
 }

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -28,7 +28,7 @@ import (
 func TestOrganizationConversion(t *testing.T) {
 	t.Run("JWK is converted correctly from DB", func(t *testing.T) {
 		em := make([]interface{}, 1)
-		em[0] = map[string]interface{}{"kty":"EC"}
+		em[0] = map[string]interface{}{"kty": "EC"}
 
 		o := Organization{}.fromDb(db.Organization{Keys: em})
 
@@ -37,7 +37,7 @@ func TestOrganizationConversion(t *testing.T) {
 	})
 
 	t.Run("JWK is converted correctly to DB", func(t *testing.T) {
-		em := []JWK{{AdditionalProperties: map[string]interface{}{"kty":"EC"}}}
+		em := []JWK{{AdditionalProperties: map[string]interface{}{"kty": "EC"}}}
 		o := Organization{Keys: &em}.toDb()
 
 		assert.Len(t, o.Keys, 1)

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -20,9 +20,10 @@
 package api
 
 import (
+	"testing"
+
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestOrganizationConversion(t *testing.T) {

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -1,0 +1,46 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2019. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package api
+
+import (
+	"github.com/nuts-foundation/nuts-registry/pkg/db"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOrganizationConversion(t *testing.T) {
+	t.Run("JWK is converted correctly from DB", func(t *testing.T) {
+		em := make([]interface{}, 1)
+		em[0] = map[string]interface{}{"kty":"EC"}
+
+		o := Organization{}.fromDb(db.Organization{Keys: em})
+
+		assert.Len(t, *o.Keys, 1)
+		assert.Equal(t, "EC", (*o.Keys)[0].AdditionalProperties["kty"].(string))
+	})
+
+	t.Run("JWK is converted correctly to DB", func(t *testing.T) {
+		em := []JWK{{AdditionalProperties: map[string]interface{}{"kty":"EC"}}}
+		o := Organization{Keys: &em}.toDb()
+
+		assert.Len(t, o.Keys, 1)
+		assert.Equal(t, "EC", o.Keys[0].(map[string]interface{})["kty"].(string))
+	})
+}

--- a/api/generated.go
+++ b/api/generated.go
@@ -5,13 +5,10 @@ package api
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"io"
@@ -839,61 +836,5 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.GET("/api/organizations", wrapper.SearchOrganizations)
 	router.POST("/api/organizations", wrapper.RegisterOrganization)
 
-}
-
-// Base64 encoded, gzipped, json marshaled Swagger object
-var swaggerSpec = []string{
-
-	"H4sIAAAAAAAC/9RY33PjthH+V3bQzvQyw6Mk281d+RZ3kqviu7PHiSdtUz9AwEpCDAEMAMrHevS/dxYQ",
-	"JZKibN1cppP4xTTxY3e//fbbpZ+YsKvSGjTBs+KJebHEFY+P3xpZWmUCPZfOluiCwrhyd/uefkn0wqky",
-	"KGtYwbQVnB7BziEsEbgIFdeABnB7EVgTV5QJ6AwGljH8xFelRlawIMpiNJqcvcnH+TifFJOz84sMliGU",
-	"vhiNTBV8bvSouYplLNQlnfPBKbNgm4w1az/Ghb57d7fTxjM6Sc+ty/Z+VM4UZK1oVgthjcdhk0qiCWqu",
-	"0JHBPzucs4L9abSHdLTFczTd79xkzAceKn/oZHrf+Nn2z1QrVvzMuAhqjSxjUnk+0yjZ/YBba3Q+Xti/",
-	"f7sAplrN0PXtZFB5lBAsSOWDMotK+SXMMDwiGqjKheMSfQ+5nvFNxhz+WimHkvzt5KSD1w6EvbtZJNb9",
-	"JttR79otuFH/5WEwmg+8LJVZ7DxsTnngRkL7LFnpUhhb5D49b7bnz+8k40dAZz2Hd14QxNMOdbtOvUOD",
-	"TgnYpysxY24dOCwdUj0Q8pc/fMyAL2bCSswAg8hhGv7igetHXnugygmuEgElcMoK3N1+hLnV2j6ihFkN",
-	"HKStZhpBWG0NvCq+irkLS9xKRfKgJmNrritskFqoNcbr/mMOytcqWZzlk6/ztxfjfJJPJudv357nZ/lF",
-	"/nV+Xvxt+zMeKujvf7oiOLiUirDg+qbFmuAqzHpQcQ/pxSwF1AhWsFb7XGGY59YtRsuw0iM3F2/+OnmT",
-	"wwcrUesEip39giKAt6DVzHGn0IPgBkruPCa5sg9oPD2uPOo1+nzveTpNnvdLZZju8Q8VcOVfou9O/Tc7",
-	"Y9w5Xn+J7D1gfboDlIoB24avBtSdcHpErV8/GPtogDZFttL7Xg3sufJv6xYLZ7GEj1XwQ3Qoq5lW4grr",
-	"Q4s3334ANER8CWkbPGANryTVh+ABZZRT+P6nq69elMkYVAfX+w3tUWZuD01/czMFX6JQc7VtuRTq7c3f",
-	"waNbK4Ee+JorTXIBPEQQqKW9drhQPriaZUwrgcZHJBOi7N3N+/V5RFyFCA+BAs0RaIy29LpgVF7jKIwl",
-	"Gl4qVrBz6t8ktzwsY45HvFSjDv8WGGWX+Bndn0pW7Bl6WScq+2aN7nJ8hQGdZ8XPB2iAVj6QLtjWuZZ2",
-	"eepov1boasIp76xwhzH5MG29fFRhCal+AL3g1GQoO2Qt3sMaGpK+TiVRZ5/NpBKJxR2y9+eR9zv+tIwP",
-	"sbBbApusf9WPAzMNkEPoIw1xkWK0Dr77x/T2SCghteh9IHOufSeSAw73HbFG1+AwVM6Ar4RA7+eV1uDQ",
-	"VzqAmgNysdxqdydby9Qe9pNiUvldEDG+DGxYontUHuFiPD4SB7knwkmRzKzVyA3bbO5puy9p0ou5OhuP",
-	"6ZewJmAaEgJ+CqNSc2X2Y/JvIKZU5V0Qr6+gcSUxsaH3mmsldxC9bssahKrU6LO0d8VrmCHgqgxRMi9e",
-	"CGariKlRxEPFE4vdllTAHq+rmMg03UTMW8c63sUwlIR/grTowdgAS77Gg4wTh/8VxfE46Q7wUkZY52IP",
-	"Re7EMpV6uqVarbirWcG+U2YPnYcZp3HGmuOhxSmkX1OvbJmmgqjofOHb0xaNVZssyV07+tGTkptU/xoD",
-	"HiqfxCSy6K67nepZ2WvrR2esPn0WmhTj9POmKSUS7X0lKfmssPUzc1hDZ4ey12J3oubFiXX2Ig/uTOr9",
-	"nXbfZcEtruy6OxDQzBbjbNJpO58NNCkPtqv2tsv65S71R0jXqZL3nNJdd9H/XHXroH9Uzv6fnHmH4fMI",
-	"M6QBx8eepFkH36rPUemHJHPbqIabYPPn6XQ4aObXrWaOn7igRASxpC6TvgNpDETQ1j5U5RE34rnfVyvu",
-	"EvSL2/FphD2p/6Zm225i2wb727fDLYUoj7ZHveM6WFo/QOAjvWs7uV1aWfdi52Wpt98to1+8/SJt6dJ7",
-	"c8CcyUADatcyjZ0zRAPCIX2ytafWz0zd9cDAs/vvSSPcwLVDLmtoUEPJnkuh5IH3UveNlDQ3dac/u52W",
-	"d593R8Vps/lfAAAA//8IvWMx8hUAAA==",
-}
-
-// GetSwagger returns the Swagger specification corresponding to the generated code
-// in this file.
-func GetSwagger() (*openapi3.Swagger, error) {
-	zipped, err := base64.StdEncoding.DecodeString(strings.Join(swaggerSpec, ""))
-	if err != nil {
-		return nil, fmt.Errorf("error base64 decoding spec: %s", err)
-	}
-	zr, err := gzip.NewReader(bytes.NewReader(zipped))
-	if err != nil {
-		return nil, fmt.Errorf("error decompressing spec: %s", err)
-	}
-	var buf bytes.Buffer
-	_, err = buf.ReadFrom(zr)
-	if err != nil {
-		return nil, fmt.Errorf("error decompressing spec: %s", err)
-	}
-
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData(buf.Bytes())
-	if err != nil {
-		return nil, fmt.Errorf("error loading Swagger: %s", err)
-	}
-	return swagger, nil
 }
 

--- a/api/generated.go
+++ b/api/generated.go
@@ -5,11 +5,15 @@ package api
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -35,10 +39,16 @@ type EndpointOrganization struct {
 // Identifier defines model for Identifier.
 type Identifier string
 
+// JWK defines model for JWK.
+type JWK struct {
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
 // Organization defines model for Organization.
 type Organization struct {
 	Endpoints  *[]Endpoint `json:"endpoints,omitempty"`
 	Identifier Identifier  `json:"identifier"`
+	Keys       *[]JWK      `json:"keys,omitempty"`
 	Name       string      `json:"name"`
 	PublicKey  *string     `json:"publicKey,omitempty"`
 }
@@ -61,6 +71,59 @@ type registerOrganizationJSONBody Organization
 
 // RegisterOrganizationRequestBody defines body for RegisterOrganization for application/json ContentType.
 type RegisterOrganizationJSONRequestBody registerOrganizationJSONBody
+
+// Getter for additional properties for JWK. Returns the specified
+// element and whether it was found
+func (a JWK) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for JWK
+func (a *JWK) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for JWK to handle AdditionalProperties
+func (a *JWK) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for JWK to handle AdditionalProperties
+func (a JWK) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+		}
+	}
+	return json.Marshal(object)
+}
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
@@ -776,5 +839,61 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.GET("/api/organizations", wrapper.SearchOrganizations)
 	router.POST("/api/organizations", wrapper.RegisterOrganization)
 
+}
+
+// Base64 encoded, gzipped, json marshaled Swagger object
+var swaggerSpec = []string{
+
+	"H4sIAAAAAAAC/9RY33PjthH+V3bQzvQyw6Mk281d+RZ3kqviu7PHiSdtUz9AwEpCDAEMAMrHevS/dxYQ",
+	"JZKibN1cppP4xTTxY3e//fbbpZ+YsKvSGjTBs+KJebHEFY+P3xpZWmUCPZfOluiCwrhyd/uefkn0wqky",
+	"KGtYwbQVnB7BziEsEbgIFdeABnB7EVgTV5QJ6AwGljH8xFelRlawIMpiNJqcvcnH+TifFJOz84sMliGU",
+	"vhiNTBV8bvSouYplLNQlnfPBKbNgm4w1az/Ghb57d7fTxjM6Sc+ty/Z+VM4UZK1oVgthjcdhk0qiCWqu",
+	"0JHBPzucs4L9abSHdLTFczTd79xkzAceKn/oZHrf+Nn2z1QrVvzMuAhqjSxjUnk+0yjZ/YBba3Q+Xti/",
+	"f7sAplrN0PXtZFB5lBAsSOWDMotK+SXMMDwiGqjKheMSfQ+5nvFNxhz+WimHkvzt5KSD1w6EvbtZJNb9",
+	"JttR79otuFH/5WEwmg+8LJVZ7DxsTnngRkL7LFnpUhhb5D49b7bnz+8k40dAZz2Hd14QxNMOdbtOvUOD",
+	"TgnYpysxY24dOCwdUj0Q8pc/fMyAL2bCSswAg8hhGv7igetHXnugygmuEgElcMoK3N1+hLnV2j6ihFkN",
+	"HKStZhpBWG0NvCq+irkLS9xKRfKgJmNrritskFqoNcbr/mMOytcqWZzlk6/ztxfjfJJPJudv357nZ/lF",
+	"/nV+Xvxt+zMeKujvf7oiOLiUirDg+qbFmuAqzHpQcQ/pxSwF1AhWsFb7XGGY59YtRsuw0iM3F2/+OnmT",
+	"wwcrUesEip39giKAt6DVzHGn0IPgBkruPCa5sg9oPD2uPOo1+nzveTpNnvdLZZju8Q8VcOVfou9O/Tc7",
+	"Y9w5Xn+J7D1gfboDlIoB24avBtSdcHpErV8/GPtogDZFttL7Xg3sufJv6xYLZ7GEj1XwQ3Qoq5lW4grr",
+	"Q4s3334ANER8CWkbPGANryTVh+ABZZRT+P6nq69elMkYVAfX+w3tUWZuD01/czMFX6JQc7VtuRTq7c3f",
+	"waNbK4Ee+JorTXIBPEQQqKW9drhQPriaZUwrgcZHJBOi7N3N+/V5RFyFCA+BAs0RaIy29LpgVF7jKIwl",
+	"Gl4qVrBz6t8ktzwsY45HvFSjDv8WGGWX+Bndn0pW7Bl6WScq+2aN7nJ8hQGdZ8XPB2iAVj6QLtjWuZZ2",
+	"eepov1boasIp76xwhzH5MG29fFRhCal+AL3g1GQoO2Qt3sMaGpK+TiVRZ5/NpBKJxR2y9+eR9zv+tIwP",
+	"sbBbApusf9WPAzMNkEPoIw1xkWK0Dr77x/T2SCghteh9IHOufSeSAw73HbFG1+AwVM6Ar4RA7+eV1uDQ",
+	"VzqAmgNysdxqdydby9Qe9pNiUvldEDG+DGxYontUHuFiPD4SB7knwkmRzKzVyA3bbO5puy9p0ou5OhuP",
+	"6ZewJmAaEgJ+CqNSc2X2Y/JvIKZU5V0Qr6+gcSUxsaH3mmsldxC9bssahKrU6LO0d8VrmCHgqgxRMi9e",
+	"CGariKlRxEPFE4vdllTAHq+rmMg03UTMW8c63sUwlIR/grTowdgAS77Gg4wTh/8VxfE46Q7wUkZY52IP",
+	"Re7EMpV6uqVarbirWcG+U2YPnYcZp3HGmuOhxSmkX1OvbJmmgqjofOHb0xaNVZssyV07+tGTkptU/xoD",
+	"HiqfxCSy6K67nepZ2WvrR2esPn0WmhTj9POmKSUS7X0lKfmssPUzc1hDZ4ey12J3oubFiXX2Ig/uTOr9",
+	"nXbfZcEtruy6OxDQzBbjbNJpO58NNCkPtqv2tsv65S71R0jXqZL3nNJdd9H/XHXroH9Uzv6fnHmH4fMI",
+	"M6QBx8eepFkH36rPUemHJHPbqIabYPPn6XQ4aObXrWaOn7igRASxpC6TvgNpDETQ1j5U5RE34rnfVyvu",
+	"EvSL2/FphD2p/6Zm225i2wb727fDLYUoj7ZHveM6WFo/QOAjvWs7uV1aWfdi52Wpt98to1+8/SJt6dJ7",
+	"c8CcyUADatcyjZ0zRAPCIX2ytafWz0zd9cDAs/vvSSPcwLVDLmtoUEPJnkuh5IH3UveNlDQ3dac/u52W",
+	"d593R8Vps/lfAAAA//8IvWMx8hUAAA==",
+}
+
+// GetSwagger returns the Swagger specification corresponding to the generated code
+// in this file.
+func GetSwagger() (*openapi3.Swagger, error) {
+	zipped, err := base64.StdEncoding.DecodeString(strings.Join(swaggerSpec, ""))
+	if err != nil {
+		return nil, fmt.Errorf("error base64 decoding spec: %s", err)
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(zipped))
+	if err != nil {
+		return nil, fmt.Errorf("error decompressing spec: %s", err)
+	}
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(zr)
+	if err != nil {
+		return nil, fmt.Errorf("error decompressing spec: %s", err)
+	}
+
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData(buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("error loading Swagger: %s", err)
+	}
+	return swagger, nil
 }
 

--- a/api/generated.go
+++ b/api/generated.go
@@ -837,4 +837,3 @@ func RegisterHandlers(router runtime.EchoRouter, si ServerInterface) {
 	router.POST("/api/organizations", wrapper.RegisterOrganization)
 
 }
-

--- a/client/client.go
+++ b/client/client.go
@@ -20,10 +20,11 @@
 package client
 
 import (
+	"time"
+
 	"github.com/nuts-foundation/nuts-registry/api"
 	"github.com/nuts-foundation/nuts-registry/pkg"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 // NewRegistryClient creates a new Local- or RemoteClient for the nuts registry

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "api/generated.go"

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -232,4 +232,3 @@ components:
       description: as described by https://tools.ietf.org/html/rfc7517. Modelled as object so libraries can parse the tokens themselves.
       additionalProperties: true
       type: object
-      

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -192,7 +192,11 @@ components:
             $ref: "#/components/schemas/Endpoint"
         publicKey:
           type: string
-          description: "PEM encoded public key"
+          description: "PEM encoded public key (deprecated, use JWK)"
+        keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/JWK"
     Endpoint:
       required:
         - endpointType
@@ -224,3 +228,42 @@ components:
         Generic identifier used for representing BSN, agbcode, etc.
         It's always constructed as an URN followed by a double colon (:) and then the identifying value of the given URN
       example: urn:oid:2.16.840.1.113883.2.4.6.3:999999990
+    JWK:
+      description: as described by https://tools.ietf.org/html/rfc7517. Modelled as object so libraries can parse the tokens themselves.
+      additionalProperties: true
+      type: object
+#      required:
+#        - kty
+#      properties:
+#        kty:
+#          description: "Key type. Current supported values are: oct, RSA, EC"
+#          type: string
+#        use:
+#          description: "Intended use. "
+#          type: string
+#        kid:
+#          type: string
+#        alg:
+#          type: string
+#        n:
+#          type: string
+#        e:
+#          type: string
+#        crv:
+#          type: string
+#        x:
+#          type: string
+#        y:
+#          type: string
+#        d:
+#          type: string
+#        p:
+#          type: string
+#        q:
+#          type: string
+#        dp:
+#          type: string
+#        dq:
+#          type: string
+#        qi:
+#          type: string

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -232,38 +232,4 @@ components:
       description: as described by https://tools.ietf.org/html/rfc7517. Modelled as object so libraries can parse the tokens themselves.
       additionalProperties: true
       type: object
-#      required:
-#        - kty
-#      properties:
-#        kty:
-#          description: "Key type. Current supported values are: oct, RSA, EC"
-#          type: string
-#        use:
-#          description: "Intended use. "
-#          type: string
-#        kid:
-#          type: string
-#        alg:
-#          type: string
-#        n:
-#          type: string
-#        e:
-#          type: string
-#        crv:
-#          type: string
-#        x:
-#          type: string
-#        y:
-#          type: string
-#        d:
-#          type: string
-#        p:
-#          type: string
-#        q:
-#          type: string
-#        dp:
-#          type: string
-#        dq:
-#          type: string
-#        qi:
-#          type: string
+      

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -20,6 +20,9 @@
 package engine
 
 import (
+	"os"
+	"os/signal"
+
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/labstack/echo/v4"
 	core "github.com/nuts-foundation/nuts-go-core"
@@ -29,8 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"os"
-	"os/signal"
 )
 
 // NewRegistryEngine returns the core definition for the registry

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/deepmap/oapi-codegen v1.3.0
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/getkin/kin-openapi v0.2.0
 	github.com/golang/mock v1.3.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/labstack/echo/v4 v4.1.11

--- a/go.mod
+++ b/go.mod
@@ -5,15 +5,18 @@ go 1.13
 require (
 	github.com/deepmap/oapi-codegen v1.3.0
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/getkin/kin-openapi v0.2.0
 	github.com/golang/mock v1.3.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/labstack/echo/v4 v4.1.11
 	github.com/labstack/gommon v0.3.0
+	github.com/lestrrat-go/jwx v0.9.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a
 	github.com/pelletier/go-toml v1.5.0 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb h1:Sdh/K8bSx/PG/5pD5WArKu7JEksDOShZXvSVSXuOA88=
-github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb/go.mod h1:tPPkfE9y+T+jTc8klZ0B8FXtc23p9NIpg5BjI+FIiEs=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a h1:0r1YHKAMSiP6yFy322lNclOU53LVfdkuRFsdQBJ/NU0=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvf
 github.com/labstack/gommon v0.2.9/go.mod h1:E8ZTmW9vw5az5/ZyHWCp0Lw4OH2ecsaBP1C/NKavGG4=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/lestrrat-go/jwx v0.9.0 h1:Fnd0EWzTm0kFrBPzE/PEPp9nzllES5buMkksPMjEKpM=
+github.com/lestrrat-go/jwx v0.9.0/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -70,7 +70,7 @@ func (o Organization) KeysAsSet() (jwk.Set, error) {
 	if len(o.Keys) == 0 {
 		return set, nil
 	}
-	
+
 	m := make(map[string]interface{})
 	m["keys"] = o.Keys
 	err := set.ExtractMap(m)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -56,10 +56,10 @@ func (i Identifier) String() string {
 
 // Organization defines component schema for Organization.
 type Organization struct {
-	Identifier Identifier 		`json:"identifier"`
-	Name       string     		`json:"name"`
-	PublicKey  *string    		`json:"publicKey,omitempty"`
-	Keys       []interface{} 	`json:"keys,omitempty"`
+	Identifier Identifier    `json:"identifier"`
+	Name       string        `json:"name"`
+	PublicKey  *string       `json:"publicKey,omitempty"`
+	Keys       []interface{} `json:"keys,omitempty"`
 	Endpoints  []Endpoint
 }
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+
 	"github.com/lestrrat-go/jwx/jwk"
 )
 
@@ -64,18 +65,16 @@ type Organization struct {
 }
 
 // KeysAsSet transforms the raw map in Keys to a jwk.Set. If no keys are present, it'll return an empty set
-func (o Organization) KeysAsSet() (*jwk.Set, error) {
-	if len(o.Keys) == 0 {
-		return &jwk.Set{}, nil
-	}
-
+func (o Organization) KeysAsSet() (jwk.Set, error) {
 	var set jwk.Set
+	if len(o.Keys) == 0 {
+		return set, nil
+	}
+	
 	m := make(map[string]interface{})
 	m["keys"] = o.Keys
-	if err := set.ExtractMap(m); err != nil {
-		return nil, err
-	}
-	return &set, nil
+	err := set.ExtractMap(m)
+	return set, err
 }
 
 // CurrentPublicKey returns the first current active public key. If a JWK set is registered, it'll search in the keys there.

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -63,8 +63,12 @@ type Organization struct {
 	Endpoints  []Endpoint
 }
 
-// KeysAsSet transforms the raw map in Keys to a jwk.Set
+// KeysAsSet transforms the raw map in Keys to a jwk.Set. If no keys are present, it'll return an empty set
 func (o Organization) KeysAsSet() (*jwk.Set, error) {
+	if len(o.Keys) == 0 {
+		return &jwk.Set{}, nil
+	}
+
 	var set jwk.Set
 	m := make(map[string]interface{})
 	m["keys"] = o.Keys

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -21,15 +21,16 @@ package db
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestOrganization_KeysAsSet(t *testing.T) {
 	valid := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
 	invalidKeys := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": {\"kty\":\"EC\"}}"
-	
+
 	t.Run("No keys returns empty set", func(t *testing.T) {
 		o := Organization{}
 		set, err := o.KeysAsSet()
@@ -62,9 +63,8 @@ func TestOrganization_KeysAsSet(t *testing.T) {
 				},
 			},
 		}
-		set, err := o.KeysAsSet()
+		_, err := o.KeysAsSet()
 		assert.Error(t, err)
-		assert.Nil(t, set)
 	})
 
 	t.Run("invalid combination in JWK set returns error", func(t *testing.T) {
@@ -73,14 +73,13 @@ func TestOrganization_KeysAsSet(t *testing.T) {
 				map[string]interface{}{
 					"kty": "EC",
 					"crv": "P-256",
-					"x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-					"z": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+					"x":   "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+					"z":   "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
 				},
 			},
 		}
-		set, err := o.KeysAsSet()
+		_, err := o.KeysAsSet()
 		assert.Error(t, err)
-		assert.Nil(t, set)
 	})
 }
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -29,9 +29,7 @@ import (
 func TestOrganization_KeysAsSet(t *testing.T) {
 	valid := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
 	invalidKeys := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": {\"kty\":\"EC\"}}"
-	invalidKty := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"error\"}]}"
-	invalidData := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"z\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
-
+	
 	t.Run("No keys returns empty set", func(t *testing.T) {
 		o := Organization{}
 		set, err := o.KeysAsSet()
@@ -57,21 +55,32 @@ func TestOrganization_KeysAsSet(t *testing.T) {
 	})
 
 	t.Run("invalid contents in JWK set returns error", func(t *testing.T) {
-		o := Organization{}
-		if assert.NoError(t, json.Unmarshal([]byte(invalidKty), &o)) {
-			set, err := o.KeysAsSet()
-			assert.Error(t, err)
-			assert.Nil(t, set)
+		o := Organization{
+			Keys: []interface{}{
+				map[string]interface{}{
+					"kty": "error",
+				},
+			},
 		}
+		set, err := o.KeysAsSet()
+		assert.Error(t, err)
+		assert.Nil(t, set)
 	})
 
 	t.Run("invalid combination in JWK set returns error", func(t *testing.T) {
-		o := Organization{}
-		if assert.NoError(t, json.Unmarshal([]byte(invalidData), &o)) {
-			set, err := o.KeysAsSet()
-			assert.Error(t, err)
-			assert.Nil(t, set)
+		o := Organization{
+			Keys: []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+					"crv": "P-256",
+					"x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+					"z": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+				},
+			},
 		}
+		set, err := o.KeysAsSet()
+		assert.Error(t, err)
+		assert.Nil(t, set)
 	})
 }
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -83,8 +83,8 @@ func TestOrganization_CurrentPublicKey(t *testing.T) {
 		map[string]interface{}{
 			"kty": "EC",
 			"crv": "P-256",
-			"x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
-			"y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+			"x":   "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+			"y":   "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
 			"use": "enc",
 			"kid": "1",
 		},
@@ -94,7 +94,7 @@ func TestOrganization_CurrentPublicKey(t *testing.T) {
 			"kty": "nil",
 		},
 	}
-	
+
 	t.Run("using old public key", func(t *testing.T) {
 		o := Organization{PublicKey: &oldKey}
 		key, err := o.CurrentPublicKey()

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -76,27 +76,57 @@ func TestOrganization_KeysAsSet(t *testing.T) {
 }
 
 func TestOrganization_CurrentPublicKey(t *testing.T) {
-	oldKey := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"actors\": [{\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000007\"}],\"publicKey\": \"-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\\n0wIDAQAB\\n-----END PUBLIC KEY-----\"}"
+	oldKey := "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----"
+	oldKeyCorrupt := "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQ\n-----END PUBLIC KEY-----"
 
-	newKey := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"actors\": [{\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000007\"}],\"publicKey\": \"-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\\n0wIDAQAB\\n-----END PUBLIC KEY-----\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
+	newKey := []interface{}{
+		map[string]interface{}{
+			"kty": "EC",
+			"crv": "P-256",
+			"x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+			"y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+			"use": "enc",
+			"kid": "1",
+		},
+	}
+	newKeyCorrupt := []interface{}{
+		map[string]interface{}{
+			"kty": "nil",
+		},
+	}
 	
 	t.Run("using old public key", func(t *testing.T) {
-		o := Organization{}
-		if assert.NoError(t, json.Unmarshal([]byte(oldKey), &o)) {
-			key, err := o.CurrentPublicKey()
-			if assert.NoError(t, err) {
-				assert.Equal(t, jwa.RSA, key.KeyType())
-			}
+		o := Organization{PublicKey: &oldKey}
+		key, err := o.CurrentPublicKey()
+		if assert.NoError(t, err) {
+			assert.Equal(t, jwa.RSA, key.KeyType())
 		}
 	})
 
 	t.Run("using new JWK style keys", func(t *testing.T) {
-		o := Organization{}
-		if assert.NoError(t, json.Unmarshal([]byte(newKey), &o)) {
-			key, err := o.CurrentPublicKey()
-			if assert.NoError(t, err) {
-				assert.Equal(t, jwa.EC, key.KeyType())
-			}
+		o := Organization{PublicKey: &oldKey, Keys: newKey}
+		key, err := o.CurrentPublicKey()
+		if assert.NoError(t, err) {
+			assert.Equal(t, jwa.EC, key.KeyType())
 		}
+	})
+
+	t.Run("Invalid old style key", func(t *testing.T) {
+		emptyKey := ""
+		o := Organization{PublicKey: &emptyKey}
+		_, err := o.CurrentPublicKey()
+		assert.Error(t, err)
+	})
+
+	t.Run("Corrupt old style key", func(t *testing.T) {
+		o := Organization{PublicKey: &oldKeyCorrupt}
+		_, err := o.CurrentPublicKey()
+		assert.Error(t, err)
+	})
+
+	t.Run("using invalid JWK", func(t *testing.T) {
+		o := Organization{PublicKey: &oldKey, Keys: newKeyCorrupt}
+		_, err := o.CurrentPublicKey()
+		assert.Error(t, err)
 	})
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,0 +1,94 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2019. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package db
+
+import (
+	"encoding/json"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOrganization_KeysAsSet(t *testing.T) {
+	valid := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
+	invalidKeys := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": {\"kty\":\"EC\"}}"
+	invalidKty := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"error\"}]}"
+	invalidData := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"z\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
+
+	t.Run("JWK set is parsed", func(t *testing.T) {
+		o := Organization{}
+		if assert.NoError(t, json.Unmarshal([]byte(valid), &o)) {
+			set, err := o.KeysAsSet()
+			if assert.NoError(t, err) && assert.NotNil(t, set) {
+				assert.Len(t, set.Keys, 1)
+				assert.Equal(t, jwa.EC, set.Keys[0].KeyType())
+			}
+		}
+	})
+
+	t.Run("invalid JWK set in json returns error", func(t *testing.T) {
+		o := Organization{}
+		assert.Error(t, json.Unmarshal([]byte(invalidKeys), &o))
+	})
+
+	t.Run("invalid contents in JWK set returns error", func(t *testing.T) {
+		o := Organization{}
+		if assert.NoError(t, json.Unmarshal([]byte(invalidKty), &o)) {
+			set, err := o.KeysAsSet()
+			assert.Error(t, err)
+			assert.Nil(t, set)
+		}
+	})
+
+	t.Run("invalid combination in JWK set returns error", func(t *testing.T) {
+		o := Organization{}
+		if assert.NoError(t, json.Unmarshal([]byte(invalidData), &o)) {
+			set, err := o.KeysAsSet()
+			assert.Error(t, err)
+			assert.Nil(t, set)
+		}
+	})
+}
+
+func TestOrganization_CurrentPublicKey(t *testing.T) {
+	oldKey := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"actors\": [{\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000007\"}],\"publicKey\": \"-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\\n0wIDAQAB\\n-----END PUBLIC KEY-----\"}"
+
+	newKey := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"actors\": [{\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000007\"}],\"publicKey\": \"-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\\n0wIDAQAB\\n-----END PUBLIC KEY-----\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"y\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
+	
+	t.Run("using old public key", func(t *testing.T) {
+		o := Organization{}
+		if assert.NoError(t, json.Unmarshal([]byte(oldKey), &o)) {
+			key, err := o.CurrentPublicKey()
+			if assert.NoError(t, err) {
+				assert.Equal(t, jwa.RSA, key.KeyType())
+			}
+		}
+	})
+
+	t.Run("using new JWK style keys", func(t *testing.T) {
+		o := Organization{}
+		if assert.NoError(t, json.Unmarshal([]byte(newKey), &o)) {
+			key, err := o.CurrentPublicKey()
+			if assert.NoError(t, err) {
+				assert.Equal(t, jwa.EC, key.KeyType())
+			}
+		}
+	})
+}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -32,6 +32,14 @@ func TestOrganization_KeysAsSet(t *testing.T) {
 	invalidKty := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"error\"}]}"
 	invalidData := "{\"name\": \"Zorggroep Nuts 2\",\"identifier\": \"urn:oid:2.16.840.1.113883.2.4.6.1:00000001\",\"keys\": [{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4\",\"z\":\"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM\",\"use\":\"enc\",\"kid\":\"2\"}]}"
 
+	t.Run("No keys returns empty set", func(t *testing.T) {
+		o := Organization{}
+		set, err := o.KeysAsSet()
+		if assert.NoError(t, err) && assert.NotNil(t, set) {
+			assert.Len(t, set.Keys, 0)
+		}
+	})
+
 	t.Run("JWK set is parsed", func(t *testing.T) {
 		o := Organization{}
 		if assert.NoError(t, json.Unmarshal([]byte(valid), &o)) {

--- a/pkg/db/files.go
+++ b/pkg/db/files.go
@@ -22,10 +22,11 @@ package db
 import (
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"sort"
+
+	"github.com/sirupsen/logrus"
 )
 
 type fileError struct {

--- a/pkg/db/memory.go
+++ b/pkg/db/memory.go
@@ -48,6 +48,11 @@ func (db *MemoryDb) RegisterOrganization(org Organization) error {
 		return fmt.Errorf("error registering organization with id %s: %w", org.Identifier, ErrDuplicateOrganization)
 	}
 
+	// also validate the keys parsed from json
+	if _, err := org.KeysAsSet(); err != nil {
+		return fmt.Errorf("error registering organization with id %s: %w", org.Identifier, err)
+	}
+
 	db.appendOrganization(&org)
 
 	for _, e := range org.Endpoints {
@@ -314,6 +319,11 @@ func (db *MemoryDb) loadOrganizations(location string) error {
 	db.organizationIndex = make(map[string]*Organization)
 	db.organizationToEndpointIndex = make(map[string][]EndpointOrganization)
 	for _, e := range stub {
+		// also validate the keys parsed from json
+		if _, err := e.KeysAsSet(); err != nil {
+			return fmt.Errorf("failed to load organization %s: %w", e.Name, err)
+		}
+
 		db.appendOrganization(&e)
 	}
 

--- a/pkg/db/memory.go
+++ b/pkg/db/memory.go
@@ -23,9 +23,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type MemoryDb struct {

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -21,9 +21,10 @@ package db
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/labstack/gommon/random"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var endpoint = Endpoint{

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -175,7 +175,7 @@ func TestMemoryDb_RegisterOrganization(t *testing.T) {
 		o := Organization{
 			Identifier: Identifier(random.String(8)),
 			Name:       random.String(8),
-			Keys:       []interface{}{
+			Keys: []interface{}{
 				map[string]interface{}{
 					"kty": "EC",
 				},

--- a/test_data/valid_files/organizations.json
+++ b/test_data/valid_files/organizations.json
@@ -7,12 +7,7 @@
         "identifier": "urn:oid:2.16.840.1.113883.2.4.6.1:00000007"
       }
     ],
-    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----",
-    "keys": [{"kty":"RSA",
-      "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdk-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
-      "e":"AQAB",
-      "alg":"RS256",
-      "kid":"1"}]
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----"
   },
   {
     "name": "Zorggroep Nuts 2",

--- a/test_data/valid_files/organizations.json
+++ b/test_data/valid_files/organizations.json
@@ -7,7 +7,12 @@
         "identifier": "urn:oid:2.16.840.1.113883.2.4.6.1:00000007"
       }
     ],
-    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----"
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----",
+    "keys": [{"kty":"RSA",
+      "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdk-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+      "e":"AQAB",
+      "alg":"RS256",
+      "kid":"1"}]
   },
   {
     "name": "Zorggroep Nuts 2",
@@ -17,6 +22,12 @@
         "identifier": "urn:oid:2.16.840.1.113883.2.4.6.1:00000007"
       }
     ],
-    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----"
+    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9wJQN59PYsvIsTrFuTqS\nLoUBgwdRfpJxOa5L8nOALxNk41MlAg7xnPbvnYrOHFucfWBTDOMTKBMSmD4WDkaF\ndVrXAML61z85Le8qsXfX6f7TbKMDm2u1O3cye+KdJe8zclK9sTFzSD0PP0wfw7wf\nlACe+PfwQgeOLPUWHaR6aDfaA64QEdfIzk/IL3S595ixaEn0huxMHgXFX35Vok+o\nQdbnclSTo6HUinkqsHUu/hGHApkE3UfT6GD6SaLiB9G4rAhlrDQ71ai872t4FfoK\n7skhe8sP2DstzAQRMf9FcetrNeTxNL7Zt4F/qKm80cchRZiFYPMCYyjQphyBCoJf\n0wIDAQAB\n-----END PUBLIC KEY-----",
+    "keys": [{"kty":"EC",
+      "crv":"P-256",
+      "x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+      "y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+      "use":"enc",
+      "kid":"2"}]
   }
 ]


### PR DESCRIPTION
the json definition of an organisation now also supports the "keys" attribute.
This is a RFC7517 notation for a key. In our case for public keys.
The db.Organization type now also supports fetching the latest valid Public key which will make it simpler for API users to extract the correct key (using the client).
Loading json into the in-memory DB also check the validity of the "keys" property.

more info on: https://tools.ietf.org/html/rfc7517

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>