### PR TITLE
when converting jwkMap to JWk copy contents

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -64,6 +64,20 @@ type Organization struct {
 	Endpoints  []Endpoint
 }
 
+// copyKeys is needed since the jwkSet.extractMap consumes the contents
+func (o Organization) copyKeys() []interface{} {
+	var keys []interface{}
+	for _, k := range o.Keys {
+		nk := map[string]interface{}{}
+		m := k.(map[string]interface{})
+		for k, v := range m {
+			nk[k] = v
+		}
+		keys = append(keys, nk)
+	}
+	return keys
+}
+
 // KeysAsSet transforms the raw map in Keys to a jwk.Set. If no keys are present, it'll return an empty set
 func (o Organization) KeysAsSet() (jwk.Set, error) {
 	var set jwk.Set
@@ -72,7 +86,8 @@ func (o Organization) KeysAsSet() (jwk.Set, error) {
 	}
 
 	m := make(map[string]interface{})
-	m["keys"] = o.Keys
+
+	m["keys"] = o.copyKeys()
 	err := set.ExtractMap(m)
 	return set, err
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -50,6 +50,18 @@ func TestOrganization_KeysAsSet(t *testing.T) {
 		}
 	})
 
+	t.Run("JWK as set can be called multiple times (bug: #20)", func(t *testing.T) {
+		o := Organization{}
+		if assert.NoError(t, json.Unmarshal([]byte(valid), &o)) {
+			_, _ = o.KeysAsSet()
+			set, err := o.KeysAsSet()
+			if assert.NoError(t, err) && assert.NotNil(t, set) {
+				assert.Len(t, set.Keys, 1)
+				assert.Equal(t, jwa.EC, set.Keys[0].KeyType())
+			}
+		}
+	})
+
 	t.Run("invalid JWK set in json returns error", func(t *testing.T) {
 		o := Organization{}
 		assert.Error(t, json.Unmarshal([]byte(invalidKeys), &o))


### PR DESCRIPTION
jwk.Set.ExtractMap consumes contents. Calling KeysAsSet multiple times on an Organization then fails. Probably only a problem in test.

Fixes #20 
