### PR TITLE
Configure crypto in registry Configure() func instead of on engine creation

### DIFF
--- a/pkg/admin_test.go
+++ b/pkg/admin_test.go
@@ -153,7 +153,6 @@ func TestRegistry_VendorClaim(t *testing.T) {
 }
 
 func createRegistry(repo test.TestRepo) Registry {
-	crypto, _ := storage.NewFileSystemBackend(repo.Directory)
 	registry := Registry{
 		Config: RegistryConfig{
 			Mode:     core.ServerEngineMode,
@@ -161,13 +160,18 @@ func createRegistry(repo test.TestRepo) Registry {
 			SyncMode: "fs",
 		},
 		EventSystem: events.NewEventSystem(),
-		crypto: &pkg.Crypto{
-			Storage: crypto,
-			Config: pkg.CryptoConfig{
-				Keysize: 2048,
-			},
+	}
+	err := registry.Configure()
+	cryptoBackend, _ := storage.NewFileSystemBackend(repo.Directory)
+	registry.crypto = &pkg.Crypto{
+		Storage: cryptoBackend,
+		Config: pkg.CryptoConfig{
+			Keysize: 2048,
+			Fspath:  repo.Directory,
 		},
 	}
-	registry.Configure()
+	if err != nil {
+		panic(err)
+	}
 	return registry
 }

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -122,7 +122,6 @@ func RegistryInstance() *Registry {
 	oneRegistry.Do(func() {
 		instance = &Registry{
 			EventSystem: events.NewEventSystem(),
-			crypto:      pkg.NewCryptoClient(),
 			_logger:     logrus.StandardLogger().WithField("module", ModuleName),
 		}
 	})
@@ -136,6 +135,7 @@ func (r *Registry) Configure() error {
 
 	r.configOnce.Do(func() {
 		cfg := core.NutsConfig()
+		r.crypto = pkg.NewCryptoClient()
 		r.Config.Mode = cfg.GetEngineMode(r.Config.Mode)
 		if r.Config.Mode == core.ServerEngineMode {
 			// Apply stored events


### PR DESCRIPTION
Otherwise, auth.fsPath configuration is ignored because configuration of the crypto engine happens before configuration was injected by core.