### PR TITLE
Remove Endpoint.Version

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -61,7 +61,7 @@ func (apiResource ApiWrapper) RegisterEndpoint(ctx echo.Context, id string) erro
 	if err = ep.validate(); err != nil {
 		return ctx.String(http.StatusBadRequest, err.Error())
 	}
-	event, err := apiResource.R.RegisterEndpoint(unescapedID, ep.Identifier.String(), ep.URL, ep.EndpointType, ep.Status, ep.Version, fromEndpointProperties(ep.Properties))
+	event, err := apiResource.R.RegisterEndpoint(unescapedID, ep.Identifier.String(), ep.URL, ep.EndpointType, ep.Status, fromEndpointProperties(ep.Properties))
 	if err != nil {
 		return ctx.String(http.StatusInternalServerError, err.Error())
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -720,7 +720,7 @@ func TestApiResource_RegisterEndpoint(t *testing.T) {
 		t.Run("204", func(t *testing.T) {
 			var registryClient = mock.NewMockRegistryClient(mockCtrl)
 			e, wrapper := initMockEcho(registryClient)
-			registryClient.EXPECT().RegisterEndpoint("1", "abc", "foo:bar", "fhir", "", "", map[string]string{"key": "value"})
+			registryClient.EXPECT().RegisterEndpoint("1", "abc", "foo:bar", "fhir", "", map[string]string{"key": "value"})
 
 			props := EndpointProperties{}
 			props["key"] = "value"

--- a/api/client.go
+++ b/api/client.go
@@ -160,7 +160,7 @@ func (hb HttpClient) searchOrganization(params SearchOrganizationsParams) ([]db.
 }
 
 // RegisterEndpoint is the client Api implementation for registering an endpoint for an organisation.
-func (hb HttpClient) RegisterEndpoint(organizationID string, id string, url string, endpointType string, status string, version string, properties map[string]string) (events.Event, error) {
+func (hb HttpClient) RegisterEndpoint(organizationID string, id string, url string, endpointType string, status string, properties map[string]string) (events.Event, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), hb.Timeout)
 	defer cancel()
 	res, err := hb.client().RegisterEndpoint(ctx, organizationID, RegisterEndpointJSONRequestBody{
@@ -168,7 +168,6 @@ func (hb HttpClient) RegisterEndpoint(organizationID string, id string, url stri
 		EndpointType: endpointType,
 		Identifier:   Identifier(id),
 		Status:       status,
-		Version:      version,
 		Properties:   toEndpointProperties(properties),
 	})
 	if err != nil {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -174,7 +174,7 @@ func TestHttpClient_RegisterEndpoint(t *testing.T) {
 		s := httptest.NewServer(handler{statusCode: http.StatusOK, responseData: event.Marshal()})
 		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
 
-		event, err := c.RegisterEndpoint("orgId", "id", "url", "type", "status", "version", map[string]string{"foo": "bar"})
+		event, err := c.RegisterEndpoint("orgId", "id", "url", "type", "status", map[string]string{"foo": "bar"})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -184,7 +184,7 @@ func TestHttpClient_RegisterEndpoint(t *testing.T) {
 		s := httptest.NewServer(handler{statusCode: http.StatusInternalServerError, responseData: []byte{}})
 		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
 
-		event, err := c.RegisterEndpoint("orgId", "id", "url", "type", "status", "version", nil)
+		event, err := c.RegisterEndpoint("orgId", "id", "url", "type", "status", nil)
 		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
 		assert.Nil(t, event)
 	})

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -29,7 +29,6 @@ func (e Endpoint) fromDb(db db.Endpoint) Endpoint {
 	e.EndpointType = db.EndpointType
 	e.Identifier = Identifier(db.Identifier)
 	e.Status = db.Status
-	e.Version = db.Version
 	e.Properties = toEndpointProperties(db.Properties)
 	return e
 }
@@ -80,7 +79,6 @@ func (e Endpoint) toDb() db.Endpoint {
 		EndpointType: e.EndpointType,
 		Identifier:   db.Identifier(e.Identifier),
 		Status:       e.Status,
-		Version:      e.Version,
 		Properties:   fromEndpointProperties(e.Properties),
 	}
 }

--- a/api/generated.go
+++ b/api/generated.go
@@ -38,9 +38,6 @@ type Endpoint struct {
 
 	// status of the endpoint
 	Status string `json:"status"`
-
-	// version number of the endpoint, used to distinguish between upgrades of endpoint
-	Version string `json:"version"`
 }
 
 // EndpointProperties defines model for EndpointProperties.
@@ -100,9 +97,6 @@ type RegisterEndpointEvent struct {
 
 	// status of the endpoint
 	Status string `json:"status"`
-
-	// version number of the endpoint, used to distinguish between upgrades of endpoint
-	Version string `json:"version"`
 }
 
 // RegisterVendorEvent defines model for RegisterVendorEvent.

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -8,7 +8,6 @@ func TestEndpoint_validate(t *testing.T) {
 		EndpointType string
 		Identifier   Identifier
 		Status       string
-		Version      string
 	}
 	tests := []struct {
 		name    string
@@ -27,7 +26,6 @@ func TestEndpoint_validate(t *testing.T) {
 				EndpointType: tt.fields.EndpointType,
 				Identifier:   tt.fields.Identifier,
 				Status:       tt.fields.Status,
-				Version:      tt.fields.Version,
 			}
 			if err := e.validate(); (err != nil) != tt.wantErr {
 				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -278,7 +278,6 @@ components:
         - endpointType
         - identifier
         - status
-        - version
         - URL
       properties:
         endpointType:
@@ -291,9 +290,6 @@ components:
           type: string
           enum: ["active", "disabled"]
           description: status of the endpoint
-        version:
-          type: string
-          description: version number of the endpoint, used to distinguish between upgrades of endpoint
         URL:
           type: string
           description: location of the actual en endpoint on the internet
@@ -342,7 +338,6 @@ components:
         - endpointType
         - identifier
         - status
-        - version
         - URL
       properties:
         organization:
@@ -357,9 +352,6 @@ components:
           type: string
           enum: ["active", "disabled"]
           description: status of the endpoint
-        version:
-          type: string
-          description: version number of the endpoint, used to distinguish between upgrades of endpoint
         URL:
           type: string
           description: location of the actual en endpoint on the internet

--- a/docs/pages/administration/registry.rst
+++ b/docs/pages/administration/registry.rst
@@ -119,7 +119,7 @@ The syntax of this command is as follows:
 
 .. code-block:: shell
 
-    ./nuts registry register-endpoint <organisation-identifier> <endpoint-identifier> <type> <url> <version>
+    ./nuts registry register-endpoint <organisation-identifier> <endpoint-identifier> <type> <url>
 
 In the following example we register a Corda consent endpoint for the previously registered organisation:
 
@@ -128,8 +128,7 @@ In the following example we register a Corda consent endpoint for the previously
     NUTS_MODE=cli ./nuts registry register-endpoint urn:oid:2.16.840.1.113883.2.4.6.1:123456 \
         "urn:ietf:rfc:1779:O=BecauseWeCare B.V.,C=NL,L=Almere,CN=Kunstgebit Thuiszorg" \
         urn:nuts:endpoint:consent \
-        "tcp://1.2.3.4:4321" \
-        1.0.0
+        "tcp://1.2.3.4:4321"
 
 Endpoints can have extra metadata in the form of string properties. Property are specified as **key=value** using the **-p** flag:
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -166,13 +166,13 @@ func cmd() *cobra.Command {
 	{
 		var properties *[]string
 		command := &cobra.Command{
-			Use:   "register-endpoint [org-identifier] [identifier] [type] [url] [version]",
+			Use:   "register-endpoint [org-identifier] [identifier] [type] [url]",
 			Short: "Registers an endpoint",
 			Long:  "Registers an endpoint for an organization.",
-			Args:  cobra.ExactArgs(5),
+			Args:  cobra.ExactArgs(4),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cl := registryClientCreator()
-				event, err := cl.RegisterEndpoint(args[0], args[1], args[3], args[2], db.StatusActive, args[4], parseCLIProperties(*properties))
+				event, err := cl.RegisterEndpoint(args[0], args[1], args[3], args[2], db.StatusActive, parseCLIProperties(*properties))
 				if err != nil {
 					logrus.Errorf("Unable to register endpoint: %v", err)
 					return err

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -26,7 +26,7 @@ func TestRegisterVendor(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 	t.Run("error", withMock(func(t *testing.T, client *mock.MockRegistryClient) {
-		client.EXPECT().RegisterVendor(gomock.Any(),gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
+		client.EXPECT().RegisterVendor(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
 		command.SetArgs([]string{"register-vendor", "id", "name", "domain"})
 		command.Execute()
 	}))
@@ -52,14 +52,14 @@ func TestRegisterEndpoint(t *testing.T) {
 	command := cmd()
 	t.Run("ok", withMock(func(t *testing.T, client *mock.MockRegistryClient) {
 		event := events.CreateEvent(events.RegisterEndpoint, events.RegisterEndpointEvent{})
-		client.EXPECT().RegisterEndpoint("orgId", "id", "url", "type", db.StatusActive, "version", map[string]string{"k1": "v1", "k2": "v2"}).Return(event, nil)
-		command.SetArgs([]string{"register-endpoint", "orgId", "id", "type", "url", "version", "-p", "k1=v1", "-p", "k2=v2"})
+		client.EXPECT().RegisterEndpoint("orgId", "id", "url", "type", db.StatusActive, map[string]string{"k1": "v1", "k2": "v2"}).Return(event, nil)
+		command.SetArgs([]string{"register-endpoint", "orgId", "id", "type", "url", "-p", "k1=v1", "-p", "k2=v2"})
 		err := command.Execute()
 		assert.NoError(t, err)
 	}))
 	t.Run("error", withMock(func(t *testing.T, client *mock.MockRegistryClient) {
-		client.EXPECT().RegisterEndpoint(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
-		command.SetArgs([]string{"register-endpoint", "orgId", "id", "type", "url", "version"})
+		client.EXPECT().RegisterEndpoint(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed"))
+		command.SetArgs([]string{"register-endpoint", "orgId", "id", "type", "url"})
 		command.Execute()
 	}))
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -64,6 +64,23 @@ func TestRegisterEndpoint(t *testing.T) {
 	}))
 }
 
+func TestSearchOrg(t *testing.T) {
+	command := cmd()
+	t.Run("ok", withMock(func(t *testing.T, client *mock.MockRegistryClient) {
+		client.EXPECT().SearchOrganizations("foo")
+		command.SetArgs([]string{"search", "foo"})
+		err := command.Execute()
+		assert.NoError(t, err)
+	}))
+}
+
+func TestPrintVersion(t *testing.T) {
+	command := cmd()
+	command.SetArgs([]string{"version"})
+	err := command.Execute()
+	assert.NoError(t, err)
+}
+
 func withMock(test func(t *testing.T, client *mock.MockRegistryClient)) func(t *testing.T) {
 	return func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)

--- a/mock/mock_client.go
+++ b/mock/mock_client.go
@@ -95,18 +95,18 @@ func (mr *MockRegistryClientMockRecorder) ReverseLookup(name interface{}) *gomoc
 }
 
 // RegisterEndpoint mocks base method
-func (m *MockRegistryClient) RegisterEndpoint(organizationID, id, url, endpointType, status, version string, properties map[string]string) (events.Event, error) {
+func (m *MockRegistryClient) RegisterEndpoint(organizationID, id, url, endpointType, status string, properties map[string]string) (events.Event, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterEndpoint", organizationID, id, url, endpointType, status, version, properties)
+	ret := m.ctrl.Call(m, "RegisterEndpoint", organizationID, id, url, endpointType, status, properties)
 	ret0, _ := ret[0].(events.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RegisterEndpoint indicates an expected call of RegisterEndpoint
-func (mr *MockRegistryClientMockRecorder) RegisterEndpoint(organizationID, id, url, endpointType, status, version, properties interface{}) *gomock.Call {
+func (mr *MockRegistryClientMockRecorder) RegisterEndpoint(organizationID, id, url, endpointType, status, properties interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEndpoint", reflect.TypeOf((*MockRegistryClient)(nil).RegisterEndpoint), organizationID, id, url, endpointType, status, version, properties)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEndpoint", reflect.TypeOf((*MockRegistryClient)(nil).RegisterEndpoint), organizationID, id, url, endpointType, status, properties)
 }
 
 // VendorClaim mocks base method

--- a/pkg/admin.go
+++ b/pkg/admin.go
@@ -99,16 +99,15 @@ func (r *Registry) VendorClaim(vendorID string, orgID string, orgName string, or
 }
 
 // RegisterEndpoint registers an endpoint for an organization
-func (r *Registry) RegisterEndpoint(organizationID string, id string, url string, endpointType string, status string, version string, properties map[string]string) (events.Event, error) {
-	logrus.Infof("Registering endpoint, organization=%s, id=%s, type=%s, url=%s, status=%s, version=%s",
-		organizationID, id, endpointType, url, status, version)
+func (r *Registry) RegisterEndpoint(organizationID string, id string, url string, endpointType string, status string, properties map[string]string) (events.Event, error) {
+	logrus.Infof("Registering endpoint, organization=%s, id=%s, type=%s, url=%s, status=%s",
+		organizationID, id, endpointType, url, status)
 	return r.publishEvent(events.RegisterEndpoint, events.RegisterEndpointEvent{
 		Organization: events.Identifier(organizationID),
 		URL:          url,
 		EndpointType: endpointType,
 		Identifier:   events.Identifier(id),
 		Status:       status,
-		Version:      version,
 		Properties:   properties,
 	})
 }

--- a/pkg/admin_test.go
+++ b/pkg/admin_test.go
@@ -32,7 +32,7 @@ func TestRegistryAdministration_RegisterEndpoint(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		_, err := registry.RegisterEndpoint("orgId", "endpointId", "url", "type", "status", "version", map[string]string{"foo": "bar"})
+		_, err := registry.RegisterEndpoint("orgId", "endpointId", "url", "type", "status", map[string]string{"foo": "bar"})
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -40,7 +40,6 @@ func TestRegistryAdministration_RegisterEndpoint(t *testing.T) {
 		assert.Equal(t, "endpointId", string(event.Identifier))
 		assert.Equal(t, "url", event.URL)
 		assert.Equal(t, "type", event.EndpointType)
-		assert.Equal(t, "version", event.Version)
 		assert.Equal(t, "status", event.Status)
 		assert.Len(t, event.Properties, 1)
 	})

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -37,7 +37,6 @@ type Endpoint struct {
 	EndpointType string            `json:"endpointType"`
 	Identifier   Identifier        `json:"identifier"`
 	Status       string            `json:"status"`
-	Version      string            `json:"version"`
 	Properties   map[string]string `json:"properties,omitempty"`
 }
 

--- a/pkg/db/memory.go
+++ b/pkg/db/memory.go
@@ -89,7 +89,6 @@ func (e endpoint) toDb() Endpoint {
 		EndpointType: e.EndpointType,
 		Identifier:   toDbIdentifier(e.Identifier),
 		Status:       e.Status,
-		Version:      e.Version,
 		Properties:   e.Properties,
 	}
 }

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -64,7 +64,6 @@ var registerEndpoint1 = events.CreateEvent(events.RegisterEndpoint, events.Regis
 	EndpointType: "simple",
 	Identifier:   "e1",
 	Status:       StatusActive,
-	Version:      "1.0",
 })
 var registerEndpoint2 = events.CreateEvent(events.RegisterEndpoint, events.RegisterEndpointEvent{
 	Organization: "o1",
@@ -72,7 +71,6 @@ var registerEndpoint2 = events.CreateEvent(events.RegisterEndpoint, events.Regis
 	EndpointType: "simple",
 	Identifier:   "e2",
 	Status:       "inactive",
-	Version:      "1.0",
 })
 
 func TestNew(t *testing.T) {

--- a/pkg/events/domain.go
+++ b/pkg/events/domain.go
@@ -40,7 +40,6 @@ type RegisterEndpointEvent struct {
 	EndpointType string            `json:"endpointType"`
 	Identifier   Identifier        `json:"identifier"`
 	Status       string            `json:"status"`
-	Version      string            `json:"version"`
 	Properties   map[string]string `json:"properties,omitempty"`
 }
 

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -79,7 +79,7 @@ type RegistryClient interface {
 	ReverseLookup(name string) (*db.Organization, error)
 
 	// RegisterEndpoint registers an endpoint for an organization
-	RegisterEndpoint(organizationID string, id string, url string, endpointType string, status string, version string, properties map[string]string) (events.Event, error)
+	RegisterEndpoint(organizationID string, id string, url string, endpointType string, status string, properties map[string]string) (events.Event, error)
 
 	// VendorClaim registers an organization under a vendor. orgKeys are the organization's keys in JWK format
 	VendorClaim(vendorID string, orgID string, orgName string, orgKeys []interface{}) (events.Event, error)


### PR DESCRIPTION
Attribute is unused and it's unsure how it'll be used in practice, so for now we'll remove it.

Fixes #50 