### PR TITLE
updated to latest codegen and removed tag from vendorClaim

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -22,6 +22,9 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
+	"strings"
+
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
 	"github.com/nuts-foundation/nuts-registry/mock"
@@ -29,8 +32,6 @@ import (
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"github.com/stretchr/testify/assert"
-	"net/url"
-	"strings"
 
 	"net/http"
 	"net/http/httptest"
@@ -651,7 +652,7 @@ func TestApiResource_VendorClaim(t *testing.T) {
 			b, _ := json.Marshal(Organization{
 				Identifier: "abc",
 				Name:       "def",
-				Keys:       &[]JWK{map[string]interface{}{}},
+				Keys:       &[]JWK{{AdditionalProperties: map[string]interface{}{}}},
 			})
 
 			req := httptest.NewRequest(echo.POST, "/", bytes.NewReader(b))
@@ -730,13 +731,13 @@ func TestApiResource_RegisterEndpoint(t *testing.T) {
 			e, wrapper := initMockEcho(registryClient)
 			registryClient.EXPECT().RegisterEndpoint("1", "", "foo:bar", "fhir", "", map[string]string{"key": "value"})
 
-			props := EndpointProperties{}
+			props := map[string]string{}
 			props["key"] = "value"
 			b, _ := json.Marshal(Endpoint{
 				Identifier:   "",
 				URL:          "foo:bar",
 				EndpointType: "fhir",
-				Properties:   &props,
+				Properties:   &EndpointProperties{AdditionalProperties: props},
 			})
 
 			req := httptest.NewRequest(echo.POST, "/", bytes.NewReader(b))

--- a/api/client.go
+++ b/api/client.go
@@ -24,12 +24,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/nuts-foundation/nuts-registry/pkg/events"
 
 	core "github.com/nuts-foundation/nuts-go-core"
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
@@ -183,7 +184,7 @@ func (hb HttpClient) VendorClaim(vendorID string, orgID string, orgName string, 
 	var keys = make([]JWK, 0)
 	if orgKeys != nil {
 		for _, key := range orgKeys {
-			keys = append(keys, key.(map[string]interface{}))
+			keys = append(keys, JWK{AdditionalProperties: key.(map[string]interface{})})
 		}
 	}
 	res, err := hb.client().VendorClaim(ctx, vendorID, VendorClaimJSONRequestBody{

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -21,6 +21,7 @@ package api
 
 import (
 	"fmt"
+
 	"github.com/nuts-foundation/nuts-registry/pkg/db"
 )
 
@@ -47,7 +48,7 @@ func (o Organization) fromDb(db db.Organization) Organization {
 	keys := make([]JWK, len(db.Keys))
 
 	for i, k := range db.Keys {
-		keys[i] = k.(map[string]interface{})
+		keys[i] = JWK{AdditionalProperties: k.(map[string]interface{})}
 	}
 
 	o.Keys = &keys
@@ -86,7 +87,7 @@ func (e Endpoint) toDb() db.Endpoint {
 func fromEndpointProperties(endpointProperties *EndpointProperties) map[string]string {
 	props := make(map[string]string, 0)
 	if endpointProperties != nil {
-		for key, value := range *endpointProperties {
+		for key, value := range endpointProperties.AdditionalProperties {
 			props[key] = fmt.Sprintf("%s", value)
 		}
 	}
@@ -94,11 +95,11 @@ func fromEndpointProperties(endpointProperties *EndpointProperties) map[string]s
 }
 
 func toEndpointProperties(properties map[string]string) *EndpointProperties {
-	props := EndpointProperties{}
+	props := map[string]string{}
 	for key, value := range properties {
 		props[key] = value
 	}
-	return &props
+	return &EndpointProperties{AdditionalProperties: props}
 }
 
 func jwkToMap(jwk []JWK) []interface{} {

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -34,14 +34,14 @@ func TestOrganizationConversion(t *testing.T) {
 		o := Organization{}.fromDb(db.Organization{Keys: em})
 
 		assert.Len(t, *o.Keys, 1)
-		assert.Equal(t, "EC", (*o.Keys)[0]["kty"].(string))
+		assert.Equal(t, "EC", (*o.Keys)[0].AdditionalProperties["kty"].(string))
 	})
 
 	t.Run("JWK is converted correctly to DB", func(t *testing.T) {
-		em := []JWK{map[string]interface{}{"kty": "EC"}}
+		em := []JWK{{AdditionalProperties: map[string]interface{}{"kty": "EC"}}}
 		o := Organization{Keys: &em}.toDb()
 
 		assert.Len(t, o.Keys, 1)
-		assert.Equal(t, "EC", o.Keys[0].(JWK)["kty"].(string))
+		assert.Equal(t, "EC", o.Keys[0].(JWK).AdditionalProperties["kty"].(string))
 	})
 }

--- a/api/generated_test.go
+++ b/api/generated_test.go
@@ -20,12 +20,13 @@
 package api
 
 import (
-	"github.com/labstack/echo/v4"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/labstack/echo/v4"
 )
 
 type RestInterfaceStub struct{}
@@ -115,7 +116,7 @@ func TestServerInterfaceWrapper_EndpointsByOrganisationId(t *testing.T) {
 			return
 		}
 
-		expected := "code=400, message=Query argument orgIds is required, but not found"
+		expected := "code=400, message=query parameter 'orgIds' is required"
 		if !strings.Contains(err.Error(), expected) {
 			t.Errorf("Got message=%s, want %s", err.Error(), expected)
 		}
@@ -171,7 +172,7 @@ func TestServerInterfaceWrapper_SearchOrganizations(t *testing.T) {
 			return
 		}
 
-		expected := "code=400, message=Query argument query is required, but not found"
+		expected := "code=400, message=query parameter 'query' is required"
 		if !strings.Contains(err.Error(), expected) {
 			t.Errorf("Got message=%s, want %s", err.Error(), expected)
 		}

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -42,7 +42,7 @@ func TestOrganization_validate(t *testing.T) {
 		Name       string
 		PublicKey  *string
 	}
-	keys := &[]JWK{map[string]interface{}{}}
+	keys := &[]JWK{{AdditionalProperties: map[string]interface{}{}}}
 	tests := []struct {
 		name    string
 		fields  fields

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -33,7 +33,6 @@ paths:
       operationId: "vendorClaim"
       tags:
         - vendors
-        - organisations
       parameters:
         - name: id
           in: path

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -22,6 +22,15 @@
 package pkg
 
 import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/gommon/random"
 	core "github.com/nuts-foundation/nuts-go-core"
@@ -31,14 +40,6 @@ import (
 	"github.com/nuts-foundation/nuts-registry/test"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"sync"
-	"testing"
-	"time"
 )
 
 type ZipHandler struct {
@@ -173,7 +174,7 @@ func TestRegistry_Configure(t *testing.T) {
 			EventSystem: events.NewEventSystem(),
 		}
 		err := registry.Configure()
-		assert.EqualError(t, err, "mkdir ////events: permission denied")
+		assert.Error(t, err)
 	})
 
 	t.Run("error while loading events", func(t *testing.T) {


### PR DESCRIPTION
The vendorClaim api had an incorrect spelling for the organizations tag. But multiple tags also generate multiple client api's in Java....

All changes needed due to upgraded oapi-codegen