### PR TITLE
Moved JWK map copying (due to internals of JWK lib) to crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/labstack/echo/v4 v4.1.11
 	github.com/labstack/gommon v0.3.0
 	github.com/lestrrat-go/jwx v0.9.1
-	github.com/nuts-foundation/nuts-crypto v0.0.0-20200310093844-b3596f3bf2ba
+	github.com/nuts-foundation/nuts-crypto v0.0.0-20200323120203-f4f01dfc38b6
 	github.com/nuts-foundation/nuts-go-core v0.0.0-20200305093237-74ae80214e1c
 	github.com/pelletier/go-toml v1.5.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,12 @@ github.com/nuts-foundation/nuts-crypto v0.0.0-20200310074856-40d86e412be7 h1:phr
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200310074856-40d86e412be7/go.mod h1:txNGo50DqgKh6PLgBHaaen4BUyi/aEohxOWnOvLIndU=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200310093844-b3596f3bf2ba h1:aJl2Gyqy+3WiSi2RgMXUYg03ejmuLu0zCyKe8gU0bXQ=
 github.com/nuts-foundation/nuts-crypto v0.0.0-20200310093844-b3596f3bf2ba/go.mod h1:txNGo50DqgKh6PLgBHaaen4BUyi/aEohxOWnOvLIndU=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200317093506-a01df7665fd7 h1:bJqhj6Sh01X/dMUea4BQvD6EBOdDBwsv8PTSCAGywn0=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200317093506-a01df7665fd7/go.mod h1:QAcn/LS/vWKHYa6TxjrwFvUX+B53lh0BdGaQcwakCRs=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200323084937-f6834b5e84bc h1:TIIfQHhEjgygBezMzpk5IyObMEZ4qmE8NSQV7Rrpe8U=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200323084937-f6834b5e84bc/go.mod h1:QAcn/LS/vWKHYa6TxjrwFvUX+B53lh0BdGaQcwakCRs=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200323120203-f4f01dfc38b6 h1:WPc15+uq3PHpjvc0EB0bPs1nmwCP8NnEuukVJNft9uA=
+github.com/nuts-foundation/nuts-crypto v0.0.0-20200323120203-f4f01dfc38b6/go.mod h1:QAcn/LS/vWKHYa6TxjrwFvUX+B53lh0BdGaQcwakCRs=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a h1:0r1YHKAMSiP6yFy322lNclOU53LVfdkuRFsdQBJ/NU0=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191218133145-27ebcf628fab h1:Dxjdaw+HToUVmh2H1/pg+BFNzNWm72bqVlA3LqcCiGs=

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -120,21 +120,6 @@ func TestMemoryDb_RegisterVendor(t *testing.T) {
 		err = eventSystem.PublishEvent(registerVendor1)
 		assert.Error(t, err)
 	}))
-
-	t.Run("vendor with invalid key set", withTestContext(func(t *testing.T, eventSystem events.EventSystem, db *MemoryDb) {
-		e := events.CreateEvent(events.RegisterVendor, events.RegisterVendorEvent{
-			Identifier: "v2",
-			Name:       "Foobar",
-			Keys: []interface{}{
-				map[string]interface{}{
-					"kty": "EC",
-				},
-			},
-		})
-		err := eventSystem.PublishEvent(e)
-		assert.Error(t, err)
-		assert.Nil(t, db.vendors["v2"])
-	}))
 }
 
 func TestMemoryDb_VendorClaim(t *testing.T) {
@@ -154,25 +139,6 @@ func TestMemoryDb_VendorClaim(t *testing.T) {
 			return
 		}
 		assert.Len(t, db.vendors["v1"].orgs, 2)
-	}))
-
-	t.Run("organization with invalid key set", withTestContext(func(t *testing.T, eventSystem events.EventSystem, db *MemoryDb) {
-		err := eventSystem.PublishEvent(registerVendor1)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		e := events.CreateEvent(events.VendorClaim, events.VendorClaimEvent{
-			VendorIdentifier: "v1",
-			OrgKeys: []interface{}{
-				map[string]interface{}{
-					"kty": "EC",
-				},
-			},
-		})
-		err = eventSystem.PublishEvent(e)
-		assert.Error(t, err)
-		assert.Len(t, db.vendors["v1"].orgs, 0)
 	}))
 
 	t.Run("unknown vendor", withTestContext(func(t *testing.T, eventSystem events.EventSystem, db *MemoryDb) {

--- a/pkg/events/domain.go
+++ b/pkg/events/domain.go
@@ -1,6 +1,9 @@
 package events
 
-import "time"
+import (
+	crypto "github.com/nuts-foundation/nuts-crypto/pkg"
+	"time"
+)
 
 const (
 	// RegisterEndpoint event type
@@ -51,11 +54,15 @@ type RegisterVendorEvent struct {
 	Keys       []interface{} `json:"keys,omitempty"`
 }
 
-func (r *RegisterVendorEvent) unmarshalPostProcess() {
+func (r *RegisterVendorEvent) unmarshalPostProcess() error {
 	// Default fallback to 'healthcare' domain when none is set, for handling legacy data when 'domain' didn't exist.
 	if r.Domain == "" {
 		r.Domain = FallbackDomain
 	}
+	if err := crypto.IsJWK(r.Keys...); err != nil {
+		return err
+	}
+	return nil
 }
 
 // VendorClaimEvent event
@@ -70,4 +77,11 @@ type VendorClaimEvent struct {
 	OrgKeys []interface{} `json:"orgKeys,omitempty"`
 	Start   time.Time     `json:"start"`
 	End     *time.Time    `json:"end,omitempty"`
+}
+
+func (v VendorClaimEvent) unmarshalPostProcess() error {
+	if err := crypto.IsJWK(v.OrgKeys...); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/events/domain_test.go
+++ b/pkg/events/domain_test.go
@@ -17,6 +17,38 @@ func TestRegisterVendorEvent(t *testing.T) {
 		}
 		assert.Equal(t, "healthcare", registerVendorEvent.Domain)
 	})
+	t.Run("invalid JWK", func(t *testing.T) {
+		event := CreateEvent(RegisterVendor, RegisterVendorEvent{
+			Keys: []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+				},
+			},
+		})
+		data := event.Marshal()
+		unmarshalledEvent, _ := EventFromJSON(data)
+		var payload = RegisterVendorEvent{}
+		err := unmarshalledEvent.Unmarshal(&payload)
+		assert.Contains(t, err.Error(), "invalid JWK")
+	})
+}
+
+func TestVendorClaimEvent(t *testing.T) {
+	t.Run("invalid JWK", func(t *testing.T) {
+		event := CreateEvent(VendorClaim, VendorClaimEvent{
+			VendorIdentifier: "v1",
+			OrgKeys: []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+				},
+			},
+		})
+		data := event.Marshal()
+		unmarshalledEvent, _ := EventFromJSON(data)
+		var payload = VendorClaimEvent{}
+		err := unmarshalledEvent.Unmarshal(&payload)
+		assert.Contains(t, err.Error(), "invalid JWK")
+	})
 }
 
 func TestRegisterEndpointEvent(t *testing.T) {
@@ -31,4 +63,3 @@ func TestRegisterEndpointEvent(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -37,7 +37,7 @@ type Event interface {
 
 // unmarshalPostProcessor allows to define custom logic that should be executed after unmarshalling
 type unmarshalPostProcessor interface {
-	unmarshalPostProcess()
+	unmarshalPostProcess() error
 }
 
 // EventType defines a supported type of event, which is used for executing the right handler.
@@ -118,7 +118,9 @@ func (j jsonEvent) Unmarshal(out interface{}) error {
 	}
 	postProc, ok := out.(unmarshalPostProcessor)
 	if ok {
-		postProc.unmarshalPostProcess()
+		if err := postProc.unmarshalPostProcess(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The JWK library we're using (lestrrat/jwx) to convert a map to a JWK alters the map it's giving, leading to problems when that map is actually shared state within the application (registry in this case). For that reason we're copying the map before converting it to a JWK (which happens in the crypto lib), but this copying is a consequence of using this specific library in the first place (in crypto). Therefore, copying the map is a concern of the crypto lib and not of the applications using the crypto lib.

Also see https://github.com/nuts-foundation/nuts-crypto/pull/27