### PR TITLE
Backwards compatibility for vendors and orgs without certs

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -111,6 +111,7 @@ func (j jsonEvent) Type() EventType {
 
 func (j jsonEvent) Unmarshal(out interface{}) error {
 	if j.signatureDetails.Payload == nil {
+		// https://github.com/nuts-foundation/nuts-registry/issues/84
 		// Backwards compatibility for events that aren't signed
 		data := j.Marshal()
 		decoder := json.NewDecoder(bytes.NewReader(data))
@@ -152,5 +153,8 @@ func (j jsonEvent) Marshal() []byte {
 }
 
 func (j jsonEvent) Signature() []byte {
+	if j.JWS == "" {
+		return nil
+	}
 	return []byte(j.JWS)
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -102,6 +102,16 @@ func TestSignEvent(t *testing.T) {
 		}
 		assert.Equal(t, []byte("signature"), event.Signature())
 	})
+	t.Run("ok - no signature", func(t *testing.T) {
+		event := CreateEvent("Foobar", struct{}{})
+		err := event.Sign(func(bytes2 []byte) (bytes []byte, err error) {
+			return nil, nil
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Empty(t, event.Signature())
+	})
 	t.Run("error", func(t *testing.T) {
 		event := CreateEvent("Foobar", struct{}{})
 		err := event.Sign(func(bytes2 []byte) (bytes []byte, err error) {

--- a/pkg/events/signatures.go
+++ b/pkg/events/signatures.go
@@ -25,6 +25,7 @@ func (v SignatureValidator) RegisterEventHandlers(fn EventRegistrar, eventType [
 
 func (v SignatureValidator) validate(event Event) error {
 	if len(event.Signature()) == 0 {
+		// https://github.com/nuts-foundation/nuts-registry/issues/84
 		logrus.Warnf("Event not signed, this is accepted for now but it will be rejected in future (event = %v).", event.IssuedAt())
 	} else {
 		// TODO: event.IssuedAt is not signed, what extra safety does it add checking it against the certificate validity?


### PR DESCRIPTION
Allow:

1. Vendors without an active certificate to register organizations
2. Organizations without certificates to register endpoints