### PR TITLE
Allow administrators to reissue vendor and organization certificates

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -169,6 +169,50 @@ func TestHttpClient_RegisterVendor(t *testing.T) {
 	})
 }
 
+func TestHttpClient_RefreshVendorCertificate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		event := events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{}, nil)
+		s := httptest.NewServer(handler{statusCode: http.StatusOK, responseData: event.Marshal()})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		event, err := c.RefreshVendorCertificate()
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, event)
+	})
+	t.Run("error 500", func(t *testing.T) {
+		s := httptest.NewServer(handler{statusCode: http.StatusInternalServerError, responseData: []byte{}})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		event, err := c.RefreshVendorCertificate()
+		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
+		assert.Nil(t, event)
+	})
+}
+
+func TestHttpClient_RefreshOrganizationCertificate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		event := events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{}, nil)
+		s := httptest.NewServer(handler{statusCode: http.StatusOK, responseData: event.Marshal()})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		event, err := c.RefreshOrganizationCertificate("1234")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, event)
+	})
+	t.Run("error 500", func(t *testing.T) {
+		s := httptest.NewServer(handler{statusCode: http.StatusInternalServerError, responseData: []byte{}})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		event, err := c.RefreshOrganizationCertificate("1234")
+		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
+		assert.Nil(t, event)
+	})
+}
+
 func TestHttpClient_RegisterEndpoint(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		event := events.CreateEvent(domain.RegisterEndpoint, domain.RegisterEndpointEvent{}, nil)
@@ -188,6 +232,41 @@ func TestHttpClient_RegisterEndpoint(t *testing.T) {
 		event, err := c.RegisterEndpoint("orgId", "id", "url", "type", "status", nil)
 		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
 		assert.Nil(t, event)
+	})
+}
+
+func TestHttpClient_Verify(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		response := altVerifyResponse{Fix: false, Events: []events.Event{
+			events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{}, nil),
+			events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{}, nil),
+			events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{}, nil),
+		}}
+		responseData, _ := json.Marshal(response)
+		s := httptest.NewServer(handler{statusCode: http.StatusOK, responseData: responseData})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+		evts, fix, err := c.Verify(true)
+		assert.NoError(t, err)
+		assert.False(t, fix)
+		assert.Len(t, evts, 3)
+	})
+	t.Run("error - http status 500", func(t *testing.T) {
+		s := httptest.NewServer(handler{statusCode: http.StatusInternalServerError, responseData: []byte{}})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		evts, fix, err := c.Verify(true)
+		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
+		assert.Nil(t, evts)
+		assert.False(t, fix)
+	})
+	t.Run("error - invalid response", func(t *testing.T) {
+		s := httptest.NewServer(handler{statusCode: http.StatusOK, responseData: []byte("foobar")})
+		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
+
+		evts, fix, err := c.Verify(true)
+		assert.EqualError(t, err, "invalid character 'o' in literal false (expecting 'a')")
+		assert.Nil(t, evts)
+		assert.False(t, fix)
 	})
 }
 

--- a/api/generated_test.go
+++ b/api/generated_test.go
@@ -31,6 +31,24 @@ import (
 
 type RestInterfaceStub struct{}
 
+func (e RestInterfaceStub) Verify(ctx echo.Context, params VerifyParams) error {
+	var err error
+
+	return err
+}
+
+func (e RestInterfaceStub) RefreshOrganizationCertificate(ctx echo.Context, id string) error {
+	var err error
+
+	return err
+}
+
+func (e RestInterfaceStub) RefreshVendorCertificate(ctx echo.Context) error {
+	var err error
+
+	return err
+}
+
 func (e RestInterfaceStub) DeprecatedVendorClaim(ctx echo.Context, id string) error {
 	var err error
 

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -57,6 +57,20 @@ paths:
                 $ref: '#/components/schemas/Event'
         '400':
           description: "incorrect data"
+  /api/vendor/refresh-cert:
+    post:
+      summary: "Refreshes the vendor's certificate."
+      description: "New vendor CA certificate is issued using existing keys. If there are no keys, they're generated."
+      operationId: "refreshVendorCertificate"
+      tags:
+        - vendors
+      responses:
+        '200':
+          description: "Certificate has been refreshed"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
   /api/organization:
     post:
       summary: "Claim an organization for the current vendor (registers an organization under the vendor in the registry)."
@@ -126,6 +140,35 @@ paths:
           description: Unknown organization
           content:
             text/plain:
+              schema:
+                type: string
+  /api/organization/{id}/refresh-cert:
+    post:
+      summary: "Refreshes the organization's certificate."
+      description: "New organization certificate is issued using existing keys. If there are no keys, they're generated."
+      operationId: "refreshOrganizationCertificate"
+      tags:
+        - organizations
+      parameters:
+        - name: id
+          in: path
+          description: "URL encoded identifier"
+          required: true
+          example: "urn:oid:2.16.840.1.113883.2.4.6.1:00000007"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: "Certificate has been refreshed"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '400':
+          description: invalid request
+          content:
+            text/plain:
+              example: organization not found
               schema:
                 type: string
   /api/organization/{id}/endpoints:
@@ -240,6 +283,35 @@ paths:
                   value: "organization with id X does not have an endpoint of type Y"
               schema:
                 type: string
+  /api/admin/verify:
+    post:
+      summary: Verifies the registry data (owned by the vendor) and fixes where necessarry (e.g. issue certificates) if fix = true.
+      operationId: verify
+      tags:
+        - administration
+      parameters:
+        - name: fix
+          in: query
+          description: Wheter to fix data in the registry that's broken or requires upgrading
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fix:
+                    type: boolean
+                    description: if true, the data in the registry needs fixing/upgrading.
+                  events:
+                    type: array
+                    description: list of events that resulted from fixing the data, list may be empty
+                    items:
+                      $ref: '#/components/schemas/Event'
 components:
   schemas:
     Event:

--- a/docs/pages/administration/registry.rst
+++ b/docs/pages/administration/registry.rst
@@ -6,15 +6,20 @@ Nuts Registry Administration
 This administration guide will help you to achieve the following goals:
 
 - :ref:`register-vendor-label` (representing your company).
-- :ref:`register-organisation-label` as vendor customer, which allows you to register endpoints.
-- :ref:`register-endpoint-label` for the care organisation.
-- :ref:`update-endpoint-label` of the care organisation.
+- :ref:`register-organization-label` as vendor customer, which allows you to register endpoints.
+- :ref:`register-endpoint-label` for the care organization.
+- :ref:`update-endpoint-label` of the care organization.
+- :ref:`verify-registry-data-label`.
+- :ref:`refresh-vendor-certificate-label` of your registered vendor.
+- :ref:`refresh-organization-certificate-label` of one of your vendor's organizations.
+
+.. _update-nuts-registry-label:
 
 Updating the central Nuts Registry
 ==================================
 
 Currently, the data of the Nuts Registry is centrally hosted on Github. When you want other Nuts nodes to know about your
-vendor, care organisations and endpoints you have to submit the data, produced by the administration commands, to get it
+vendor, care organizations and endpoints you have to submit the data, produced by the administration commands, to get it
 included in the registry. To do so, you have to create a pull request on Github for the
 `nuts-foundation/nuts-registry-development <https://github.com/nuts-foundation/nuts-registry-development>`_ repository.
 Should you be unable to do so, contact the Nuts Foundation for alternatives.
@@ -48,9 +53,9 @@ Alternatively you can copy the output of the CLI commands, since they output the
 1. Registering a vendor
 =======================
 
-This command registers a vendor in the registry, giving it further access to the Nuts Registry. Afterwards, care organisations
-can be registered as the organisation's clients. When a vendor is registered, a CA certificate is issued. This certificate is used (by the vendor) to issue certificates,
-e.g. care organisation certificates.
+This command registers a vendor in the registry, giving it further access to the Nuts Registry. Afterwards, care organizations
+can be registered as the organization's clients. When a vendor is registered, a CA certificate is issued. This certificate is used (by the vendor) to issue certificates,
+e.g. care organization certificates.
 
 To register a vendor, you need its name (as registered at the Chamber of Commerce) and its identifier should be
 configured as the node's ``identity``, which is the company's URN-encoded Chamber of Commerce registration number.
@@ -73,24 +78,24 @@ If the command completes successfully, it should output the message: "Vendor reg
 
     The vendor CA certificate is currently self-signed. In the future, the vendor CA certificate will be issued by the Nuts Foundation.
 
-.. _register-organisation-label:
+.. _register-organization-label:
 
-2. Registering a care organisation
+2. Registering a care organization
 ==================================
 
-When a vendor is known in the Nuts Registry, it can register organisation by claiming them (as client). Afterwards
-the vendor can register endpoints for the organisation which are served by the vendor's Nuts node. When an organisation
-is registered, the vendor CA issues an organisation certificate. Its key is used for encrypting data exchanges and
+When a vendor is known in the Nuts Registry, it can register organization by claiming them (as client). Afterwards
+the vendor can register endpoints for the organization which are served by the vendor's Nuts node. When an organization
+is registered, the vendor CA issues an organization certificate. Its key is used for encrypting data exchanges and
 signing registry operations (e.g. registering endpoints).
 
-To register an organisation you need the organisation's name and its identifier, which is the organisation's
+To register an organization you need the organization's name and its identifier, which is the organization's
 URN-encoded AGB-code.
 
 The syntax of this command is as follows:
 
 .. code-block:: shell
 
-    ./nuts registry vendor-claim <organisation-identifier> <organisation-name>
+    ./nuts registry vendor-claim <organization-identifier> <organization-name>
 
 For example:
 
@@ -98,13 +103,13 @@ For example:
 
     NUTS_MODE=cli ./nuts registry vendor-claim urn:oid:2.16.840.1.113883.2.4.6.1:123456 "Kunstgebit Thuiszorg"
 
-If the command completes successfully, it should output the message: "Vendor organisation claim registered"
+If the command completes successfully, it should output the message: "Vendor organization claim registered"
 
 .. note::
 
-    Registering an organisation as vendor client is called *claiming* because in future instead of the vendor solely
-    registering an organisation being its client, the organisation has to do the same (claim being a client of a software
-    vendor). Only if both entities claim to have a relationship with each other, the organisation is registered being a
+    Registering an organization as vendor client is called *claiming* because in future instead of the vendor solely
+    registering an organization being its client, the organization has to do the same (claim being a client of a software
+    vendor). Only if both entities claim to have a relationship with each other, the organization is registered being a
     client of the vendor.
 
 .. _register-endpoint-label:
@@ -112,16 +117,16 @@ If the command completes successfully, it should output the message: "Vendor org
 3. Registering an endpoint
 ==========================
 
-After registering an organisation, the vendor can administer its endpoints. The endpoints are used by other Nuts nodes
-when they want to exchange data with the Nuts node serving a particular organisation.
+After registering an organization, the vendor can administer its endpoints. The endpoints are used by other Nuts nodes
+when they want to exchange data with the Nuts node serving a particular organization.
 
 The syntax of this command is as follows:
 
 .. code-block:: shell
 
-    ./nuts registry register-endpoint <organisation-identifier> <type> <url>
+    ./nuts registry register-endpoint <organization-identifier> <type> <url>
 
-In the following example we register a Corda consent endpoint for the previously registered organisation:
+In the following example we register a Corda consent endpoint for the previously registered organization:
 
 .. code-block:: shell
 
@@ -156,3 +161,71 @@ Flag  Description                                                               
 To update an endpoint, simply register it again using the ``register-endpoint`` command using the same ID. The update
 completely replaces the previous registration, so specify all relevant fields and properties. Don't forget to specify
 the ID (using the ``-i`` flag) if it was auto-generated during endpoint registration.
+
+.. _verify-registry-data-label:
+
+5. Verifying and fixing registry data
+=====================================
+
+In certain circumstances the registry data owned by your node might need maintenance. Examples are when certificates are
+missing or close to expiry, records that need to be migrated to a newer version (format) or missing signatures. The Nuts
+node performs verification on startup and will inform the you (through the logs) of any issues that need to be fixed.
+
+To verify the data using the CLI use the ``verify`` command:
+
+.. code-block:: shell
+
+    NUTS_MODE=cli ./nuts registry verify
+
+If your node's registry data needs fixing this command will inform you:
+
+.. code-block:: text
+
+    Verification complete, data must be fixed. Please rerun command with --fix or -f
+
+To apply the fixes, rerun the command with the ``-f`` flag:
+
+.. code-block:: shell
+
+    NUTS_MODE=cli ./nuts registry verify -f
+
+When data is fixed new events are emitted. It's **very important** that these events are submitted to the central
+Nuts registry (please refer to :ref:`update-nuts-registry-label`).
+
+.. note::
+
+    It's recommended to verify (and fix if necessary) your node's data after each upgrade to ensure compatibility in
+    the long term. The best way to spot problems is to inspect your node's logs when starting it after upgrading.
+
+.. _refresh-vendor-certificate-label:
+
+6. Refreshing vendor CA certificate
+===================================
+
+At some point the vendor CA certificate must be refreshed (issued again). Most often because the current certificate
+is nearing the end of its validity. If the vendor doesn't have a certificate yet this command is used to issue it.
+This command will **not** rotate (create a new) the key pair for the vendor but will create one if it doesn't exist.
+
+The syntax of this command is as follows:
+
+.. code-block:: shell
+
+    ./nuts registry refresh-vendor-cert
+
+.. _refresh-organization-certificate-label:
+
+7. Refreshing organization certificate
+======================================
+
+This works exactly the same as :ref:`refresh-vendor-certificate-label` but works on an organization.
+The syntax of this command is as follows:
+
+.. code-block:: shell
+
+    ./nuts registry refresh-organization-cert <organization-identifier>
+
+In the following example we refresh the certificate for a previously registered organization:
+
+.. code-block:: shell
+
+    NUTS_MODE=cli ./nuts registry refresh-organization-cert urn:oid:2.16.840.1.113883.2.4.6.1:123456

--- a/mock/mock_client.go
+++ b/mock/mock_client.go
@@ -138,3 +138,49 @@ func (mr *MockRegistryClientMockRecorder) RegisterVendor(name, domain interface{
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterVendor", reflect.TypeOf((*MockRegistryClient)(nil).RegisterVendor), name, domain)
 }
+
+// RefreshVendorCertificate mocks base method
+func (m *MockRegistryClient) RefreshVendorCertificate() (events.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshVendorCertificate")
+	ret0, _ := ret[0].(events.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RefreshVendorCertificate indicates an expected call of RefreshVendorCertificate
+func (mr *MockRegistryClientMockRecorder) RefreshVendorCertificate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshVendorCertificate", reflect.TypeOf((*MockRegistryClient)(nil).RefreshVendorCertificate))
+}
+
+// RefreshOrganizationCertificate mocks base method
+func (m *MockRegistryClient) RefreshOrganizationCertificate(organizationID string) (events.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshOrganizationCertificate", organizationID)
+	ret0, _ := ret[0].(events.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RefreshOrganizationCertificate indicates an expected call of RefreshOrganizationCertificate
+func (mr *MockRegistryClientMockRecorder) RefreshOrganizationCertificate(organizationID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshOrganizationCertificate", reflect.TypeOf((*MockRegistryClient)(nil).RefreshOrganizationCertificate), organizationID)
+}
+
+// Verify mocks base method
+func (m *MockRegistryClient) Verify(fix bool) ([]events.Event, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Verify", fix)
+	ret0, _ := ret[0].([]events.Event)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Verify indicates an expected call of Verify
+func (mr *MockRegistryClientMockRecorder) Verify(fix interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockRegistryClient)(nil).Verify), fix)
+}

--- a/pkg/admin_test.go
+++ b/pkg/admin_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nuts-foundation/nuts-crypto/pkg/types"
 	core "github.com/nuts-foundation/nuts-go-core"
 	"github.com/nuts-foundation/nuts-registry/pkg/cert"
-	"github.com/nuts-foundation/nuts-registry/pkg/db"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"github.com/nuts-foundation/nuts-registry/pkg/events/domain"
 	"github.com/nuts-foundation/nuts-registry/test"
@@ -276,7 +275,6 @@ func TestRegistryAdministration_RegisterVendor(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		println(string(event.Marshal()))
 		// Verify RegisterVendor event emitted
 		if !assert.NotNil(t, registerVendorEvent) {
 			return
@@ -306,6 +304,59 @@ func TestRegistryAdministration_RegisterVendor(t *testing.T) {
 		})
 		_, err := cxt.registry.RegisterVendor("Foobar Software", "healthcare")
 		assert.Contains(t, err.Error(), "unit test error")
+	})
+}
+
+func TestRegistryAdministration_RefreshVendorCertificate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		cxt := createTestContext(t)
+		defer cxt.close()
+		cxt.registry.RegisterVendor("Test Vendor", domain.HealthcareDomain)
+		event, err := cxt.registry.RefreshVendorCertificate()
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, event.Signature())
+		vendor := cxt.registry.Db.VendorByID(vendorId)
+		assert.Len(t, vendor.Keys, 2)
+	})
+	t.Run("error - vendor not found", func(t *testing.T) {
+		cxt := createTestContext(t)
+		defer cxt.close()
+		event, err := cxt.registry.RefreshVendorCertificate()
+		assert.Nil(t, event)
+		assert.EqualError(t, err, "vendor doesn't exist (id=urn:oid:1.3.6.1.4.1.54851.4:4)")
+	})
+}
+
+func TestRegistryAdministration_RefreshOrganizationCertificate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		cxt := createTestContext(t)
+		defer cxt.close()
+		cxt.registry.RegisterVendor("Test Vendor", domain.HealthcareDomain)
+		cxt.registry.VendorClaim("123", "Test Org", nil)
+		event, err := cxt.registry.RefreshOrganizationCertificate("123")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, event.Signature())
+		org, _ := cxt.registry.Db.OrganizationById("123")
+		assert.Len(t, org.Keys, 2)
+	})
+	t.Run("error - vendor not found", func(t *testing.T) {
+		cxt := createTestContext(t)
+		defer cxt.close()
+		event, err := cxt.registry.RefreshOrganizationCertificate("123")
+		assert.Nil(t, event)
+		assert.EqualError(t, err, "vendor not found (id=urn:oid:1.3.6.1.4.1.54851.4:4)")
+	})
+	t.Run("error - organization not found", func(t *testing.T) {
+		cxt := createTestContext(t)
+		defer cxt.close()
+		cxt.registry.RegisterVendor("Test Vendor", domain.HealthcareDomain)
+		event, err := cxt.registry.RefreshOrganizationCertificate("123")
+		assert.Nil(t, event)
+		assert.EqualError(t, err, "organization not found")
 	})
 }
 
@@ -353,16 +404,28 @@ func TestRegistry_signAsOrganization(t *testing.T) {
 	t.Run("error - unable to create CSR", func(t *testing.T) {
 		cxt := createTestContext(t)
 		defer cxt.close()
-		cxt.registry.vendor = db.Vendor{Name: "Vendor"}
-		_, err := cxt.registry.signAsOrganization("orgId", "", []byte{1, 2, 3}, time.Now(), true)
+		err := cxt.registry.EventSystem.ProcessEvent(events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{Identifier: vendorId, Name: "Vendor"}, nil))
+		if !assert.NoError(t, err) {
+			return
+		}
+		_, err = cxt.registry.signAsOrganization("orgId", "", []byte{1, 2, 3}, time.Now(), true)
 		assert.Equal(t, "unable to create CSR for JWS signing: missing organization name", err.Error(), )
 	})
 	t.Run("error - unable to sign JWS (CA key material missing)", func(t *testing.T) {
 		cxt := createTestContext(t)
 		defer cxt.close()
-		cxt.registry.vendor = db.Vendor{Name: "Vendor"}
-		_, err := cxt.registry.signAsOrganization("orgId", "Foobar", nil, time.Now(), true)
+		err := cxt.registry.EventSystem.ProcessEvent(events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{Identifier: vendorId, Name: "Vendor"}, nil))
+		if !assert.NoError(t, err) {
+			return
+		}
+		_, err = cxt.registry.signAsOrganization("orgId", "Foobar", nil, time.Now(), true)
 		assert.Contains(t, err.Error(), "unable to sign JWS: unknown CA")
+	})
+	t.Run("error - vendor not found", func(t *testing.T) {
+		cxt := createTestContext(t)
+		defer cxt.close()
+		_, err := cxt.registry.signAsOrganization("orgId", "Foobar", nil, time.Now(), true)
+		assert.Contains(t, err.Error(), "vendor not found (id=urn:oid:1.3.6.1.4.1.54851.4:4)")
 	})
 }
 
@@ -398,16 +461,15 @@ func createRegistry(repo *test.TestRepo) *Registry {
 		EventSystem: events.NewEventSystem(domain.GetEventTypes()...),
 	}
 	err := registry.Configure()
+	if err != nil {
+		panic(err)
+	}
 	cryptoBackend, _ := storage.NewFileSystemBackend(filepath.Join(repo.Directory, "keys"))
 	registry.crypto = &crypto.Crypto{
 		Storage: cryptoBackend,
 		Config: crypto.CryptoConfig{
 			Keysize: 2048,
 		},
-	}
-	registry.verifyAndMigrateRegistry(mockConfig{identity: "urn:oid:1.3.6.1.4.1.54851.4:4"})
-	if err != nil {
-		panic(err)
 	}
 	return &registry
 }

--- a/pkg/events/domain/domain.go
+++ b/pkg/events/domain/domain.go
@@ -81,6 +81,31 @@ func (r *RegisterVendorEvent) PostProcessUnmarshal(event events.Event) error {
 	return nil
 }
 
+// VendorEventMatcher returns an EventMatcher which matches the RegisterVendorEvent for the vendor with the specified ID.
+func VendorEventMatcher(vendorID string) events.EventMatcher {
+	return func(event events.Event) bool {
+		if event.Type() != RegisterVendor {
+			return false
+		}
+		var p = RegisterVendorEvent{}
+		_ = event.Unmarshal(&p)
+		return Identifier(vendorID) == p.Identifier
+	}
+}
+
+// OrganizationEventMatcher returns an EventMatcher which matches the VendorClaimEvent which registered the organization
+// with the specified ID for the specified vendor (also by ID).
+func OrganizationEventMatcher(vendorID string, organizationID string) events.EventMatcher {
+	return func(event events.Event) bool {
+		if event.Type() != VendorClaim {
+			return false
+		}
+		var payload = VendorClaimEvent{}
+		_ = event.Unmarshal(&payload)
+		return Identifier(vendorID) == payload.VendorIdentifier && Identifier(organizationID) == payload.OrgIdentifier
+	}
+}
+
 // VendorClaimEvent event
 type VendorClaimEvent struct {
 	VendorIdentifier Identifier `json:"vendorIdentifier"`

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -20,6 +20,33 @@ func (t *testEvent) PostProcessUnmarshal(event Event) error {
 	return nil
 }
 
+func TestEventsFromJSON(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		singleEvent := `{
+ "version": 1,
+ "type": "Test",
+ "issuedAt": "2020-04-27T10:25:22.861204915+02:00",
+ "ref": "b1aa2fd05d040d20fe55152e14c336c0ab9d0e79",
+ "prev": "010203",
+ "jws": "my.awesome.jws",
+ "payload": {
+   "Hello": "World"
+ }
+}`
+		input := "[" + singleEvent + ", " + singleEvent + "]"
+		events, err := EventsFromJSON([]byte(input))
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, events, 2)
+	})
+	t.Run("error - unmarshal", func(t *testing.T) {
+		events, err := EventsFromJSON([]byte("foobar"))
+		assert.Error(t, err)
+		assert.Empty(t, events)
+	})
+}
+
 func TestEventFromJSON(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		t.Run("v0", func(t *testing.T) {
@@ -49,6 +76,11 @@ func TestEventFromJSON(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, event)
 		})
+	})
+	t.Run("error - unmarshalling", func(t *testing.T) {
+		event, err := EventFromJSON([]byte("foobar"))
+		assert.Error(t, err)
+		assert.Nil(t, event)
 	})
 	t.Run("error - missing event type", func(t *testing.T) {
 		_, err := EventFromJSON([]byte("{}"))

--- a/pkg/events/system_test.go
+++ b/pkg/events/system_test.go
@@ -173,7 +173,7 @@ func TestLoadEventsInvalidJson(t *testing.T) {
 	system := NewEventSystem()
 	system.Configure(repo.Directory + "/events")
 	err = system.LoadAndApplyEvents()
-	assert.EqualError(t, err, "invalid character '{' looking for beginning of object key string")
+	assert.EqualError(t, err, "error reading event: 20200123091400001-InvalidJson.json: unable to parse event JSON: invalid character '{' looking for beginning of object key string")
 }
 
 func TestLoadEventsEmptyFile(t *testing.T) {
@@ -185,7 +185,7 @@ func TestLoadEventsEmptyFile(t *testing.T) {
 	system := NewEventSystem()
 	system.Configure(repo.Directory + "/events")
 	err = system.LoadAndApplyEvents()
-	assert.EqualError(t, err, "unexpected end of JSON input")
+	assert.EqualError(t, err, "error reading event: 20200123091400001-EmptyFile.json: unable to parse event JSON: unexpected end of JSON input")
 }
 
 func TestParseTimestamp(t *testing.T) {
@@ -329,7 +329,7 @@ func Test_readEvent(t *testing.T) {
 	})
 	t.Run("error - can't read file", func(t *testing.T) {
 		event, err := readEvent("asadasd", "asdsd")
-		assert.EqualError(t, err, "open asadasd: no such file or directory")
+		assert.EqualError(t, err, "unable to parse event file: open asadasd: no such file or directory")
 		assert.Nil(t, event)
 	})
 }

--- a/pkg/migrate_test.go
+++ b/pkg/migrate_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"github.com/nuts-foundation/nuts-crypto/pkg/types"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"github.com/nuts-foundation/nuts-registry/pkg/events/domain"
 	"github.com/stretchr/testify/assert"
@@ -31,55 +32,95 @@ func (m mockConfig) GetEngineMode(engineMode string) string {
 	panic("implement me")
 }
 
-func TestRegistry_verifyAndMigrateRegistry(t *testing.T) {
+func TestRegistry_verify(t *testing.T) {
 	vendorName := "vendorName"
 	orgId := "orgId"
 	orgName := "orgName"
-	t.Run("vendor not registered", func(t *testing.T) {
-		cxt := createTestContext(t)
-		defer cxt.close()
-		cxt.registry.verifyAndMigrateRegistry(mockConfig{vendorId})
+	test := func(t *testing.T, autoFix bool) {
+		t.Run("all is ok", func(t *testing.T) {
+			cxt := createTestContext(t)
+			defer cxt.close()
+			cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
+			cxt.registry.VendorClaim(orgId, orgName, nil)
+			resultingEvents, needsFixing, err := cxt.registry.Verify(autoFix)
+			assert.Empty(t, resultingEvents)
+			assert.False(t, needsFixing)
+			assert.NoError(t, err)
+		})
+		t.Run("vendor not registered", func(t *testing.T) {
+			cxt := createTestContext(t)
+			defer cxt.close()
+			cxt.registry.verify(mockConfig{vendorId}, autoFix)
+		})
+		t.Run("vendor has no certificates, issued", func(t *testing.T) {
+			cxt := createTestContext(t)
+			defer cxt.close()
+			err := cxt.registry.EventSystem.PublishEvent(events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{
+				Name:       vendorName,
+				Identifier: vendorId,
+			}, nil))
+			if !assert.NoError(t, err) {
+				return
+			}
+			events, needsFixing, err := cxt.registry.verify(mockConfig{vendorId}, autoFix)
+			assert.NoError(t, err)
+			if autoFix {
+				assert.Len(t, cxt.registry.Db.VendorByID(vendorId).Keys, 1)
+				assert.Len(t, events, 1)
+				assert.False(t, needsFixing)
+			} else {
+				assert.True(t, needsFixing)
+			}
+		})
+		t.Run("error - vendor has certificates but no key material", func(t *testing.T) {
+			cxt := createTestContext(t)
+			defer cxt.close()
+			cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
+			cxt.empty()
+			_, _, err := cxt.registry.verify(mockConfig{vendorId}, autoFix)
+			assert.Error(t, err)
+		})
+		t.Run("org has no certificates", func(t *testing.T) {
+			cxt := createTestContext(t)
+			defer cxt.close()
+			cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
+			cxt.registry.EventSystem.PublishEvent(events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{
+				VendorIdentifier: vendorId,
+				OrgIdentifier:    domain.Identifier(orgId),
+				OrgName:          orgName,
+			}, nil))
+			// Assert that the org has no keys
+			org, _ := cxt.registry.Db.OrganizationById(orgId)
+			assert.Len(t, org.Keys, 0)
+			// Migrate
+			events, needsFixing, err := cxt.registry.verify(mockConfig{vendorId}, autoFix)
+			assert.NoError(t, err)
+			// Assert a new certificate was issued
+			org, _ = cxt.registry.Db.OrganizationById(orgId)
+			if autoFix {
+				assert.Len(t, org.Keys, 1)
+				assert.Len(t, events, 1)
+				assert.False(t, needsFixing)
+			} else {
+				assert.True(t, needsFixing)
+			}
+		})
+		t.Run("error - org has certificates but no key material", func(t *testing.T) {
+			cxt := createTestContext(t)
+			defer cxt.close()
+			cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
+			cxt.registry.VendorClaim(orgId, vendorName, nil)
+			// Empty key material directory
+			cxt.empty()
+			cxt.registry.crypto.GenerateKeyPairFor(types.LegalEntity{URI: vendorId})
+			_, _, err := cxt.registry.verify(mockConfig{vendorId}, autoFix)
+			assert.Error(t, err)
+		})
+	}
+	t.Run("only verify", func(t *testing.T) {
+		test(t, false)
 	})
-	t.Run("vendor has no certificates", func(t *testing.T) {
-		cxt := createTestContext(t)
-		defer cxt.close()
-		err := cxt.registry.EventSystem.PublishEvent(events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{
-			Name:       vendorName,
-			Identifier: domain.Identifier(vendorId),
-		}, nil))
-		if !assert.NoError(t, err) {
-			return
-		}
-		cxt.registry.verifyAndMigrateRegistry(mockConfig{vendorId})
-	})
-	t.Run("vendor has certificates but no key material", func(t *testing.T) {
-		cxt := createTestContext(t)
-		defer cxt.close()
-		_, err := cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
-		if !assert.NoError(t, err) {
-			return
-		}
-		cxt.empty()
-		cxt.registry.verifyAndMigrateRegistry(mockConfig{vendorId})
-	})
-	t.Run("org has no certificates", func(t *testing.T) {
-		cxt := createTestContext(t)
-		defer cxt.close()
-		cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
-		cxt.registry.EventSystem.PublishEvent(events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{
-			VendorIdentifier: domain.Identifier(vendorId),
-			OrgIdentifier:    domain.Identifier(orgId),
-			OrgName:          orgName,
-		}, nil))
-		cxt.registry.verifyAndMigrateRegistry(mockConfig{vendorId})
-	})
-	t.Run("org has certificates but no key material", func(t *testing.T) {
-		cxt := createTestContext(t)
-		defer cxt.close()
-		cxt.registry.RegisterVendor(vendorName, domain.HealthcareDomain)
-		cxt.registry.VendorClaim(orgId, vendorName, nil)
-		// Empty key material directory
-		cxt.empty()
-		cxt.registry.verifyAndMigrateRegistry(mockConfig{vendorId})
+	t.Run("verify and migrate", func(t *testing.T) {
+		test(t, true)
 	})
 }


### PR DESCRIPTION
This PR also adds the `verify` CLI command which runs verification on the remote Nuts server. If --fix is supplied, detected problems (missing certificates) will be fixed.

Fixes #97 
Fixes #61 

After discussion with @stevenvegt: verifyAndMigrate() is executed on boot, generating keys and certificates as needed. However, the person upgrading the Nuts node might not be monitoring the log and be able to retrieve the generated event files (to make a Github PR to add them to the registry) so the data might be lost.

Thus, on boot we should verify the data but not automatically migrate it. Migration should be an administrative action to be performed by a (human?) administrator using the CLI.