### PR TITLE
Fixed readEvent() to not break Ref() calclations

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -160,7 +160,7 @@ func (j jsonEvent) Ref() Ref {
 	return sum[:]
 }
 
-func (j *jsonEvent) PreviousRef() Ref {
+func (j jsonEvent) PreviousRef() Ref {
 	return j.PreviousEvent
 }
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -232,6 +232,7 @@ func TestMarshalEvent(t *testing.T) {
 			}
 			(actual.(*jsonEvent)).ThisEventRef = nil
 			assert.Equal(t, event, actual)
+			assert.Nil(t, event.PreviousRef())
 		})
 	})
 	t.Run("marshal v1 event", func(t *testing.T) {
@@ -258,6 +259,7 @@ func TestMarshalEvent(t *testing.T) {
 			}
 			(actual.(*jsonEvent)).ThisEventRef = nil
 			assert.Equal(t, event, actual)
+			assert.NotNil(t, event.PreviousRef())
 		})
 	})
 }

--- a/pkg/events/system.go
+++ b/pkg/events/system.go
@@ -300,11 +300,13 @@ func readEvent(file string, timestamp string) (Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	t, err := parseTimestamp(timestamp)
-	if err != nil {
-		return nil, err
-	}
 	je := event.(*jsonEvent)
-	je.EventIssuedAt = t
+	if je.EventIssuedAt.IsZero() {
+		t, err := parseTimestamp(timestamp)
+		if err != nil {
+			return nil, err
+		}
+		je.EventIssuedAt = t
+	}
 	return je, nil
 }


### PR DESCRIPTION
readEvent() previously overwrote issuedAt even when it was set, whih caused Ref() calculation to produce incorrect results.

issuedAt is not present for v0 events.

Not a problem for 0.13 since prev/ref were introduced for 0.14