### PR TITLE
Process events received through Nuts Network

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ These mocks are used by other modules
 .. code-block:: shell
 
     mockgen -destination=mock/mock_client.go -package=mock -source=pkg/registry.go
+    mockgen -destination=pkg/network/mock.go -package=network -source=pkg/network/ambassador.go
     mockgen -destination=mock/mock_db.go -package=mock -source=pkg/db/db.go
 
 README

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/client.go
+++ b/api/client.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/client.go
+++ b/api/client.go
@@ -283,7 +283,7 @@ func (hb HttpClient) OrganizationById(id core.PartyID) (*db.Organization, error)
 
 // VendorCAs on the client is not implemented
 func (hb HttpClient) VendorCAs() [][]*x509.Certificate {
-	return [][]*x509.Certificate{{}}
+	return [][]*x509.Certificate{}
 }
 
 func testResponseCode(expectedStatusCode int, response *http.Response) error {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -73,6 +73,13 @@ func TestHttpClient_OrganizationById(t *testing.T) {
 			t.Errorf("Expected return organization identifier to be [%s], got [%s]", organizations[0].Identifier, res.Identifier)
 		}
 	})
+
+	t.Run("http execution error", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "localhost:9876", Timeout: time.Second}
+		event, err := c.OrganizationById(test.OrganizationID("id"))
+		assert.Contains(t, err.Error(), "connection refused")
+		assert.Nil(t, event)
+	})
 }
 
 func TestHttpClient_SearchOrganizations(t *testing.T) {
@@ -149,6 +156,20 @@ func TestHttpClient_VendorClaim(t *testing.T) {
 		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
 		assert.Nil(t, event)
 	})
+	t.Run("http execution error", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "localhost:9876", Timeout: time.Second}
+		event, err := c.VendorClaim(test.OrganizationID("orgID"), "name", []interface{}{})
+		assert.Contains(t, err.Error(), "connection refused")
+		assert.Nil(t, event)
+	})
+}
+
+func TestHttpClient_VendorCAs(t *testing.T) {
+	t.Run("not implemented", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "", Timeout: time.Second}
+		vendorCAs := c.VendorCAs()
+		assert.Empty(t, vendorCAs)
+	})
 }
 
 func TestHttpClient_RegisterVendor(t *testing.T) {
@@ -170,6 +191,12 @@ func TestHttpClient_RegisterVendor(t *testing.T) {
 		c := HttpClient{ServerAddress: s.URL, Timeout: time.Second}
 		event, err := c.RegisterVendor(certificate)
 		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
+		assert.Nil(t, event)
+	})
+	t.Run("http execution error", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "localhost:9876", Timeout: time.Second}
+		event, err := c.RegisterVendor(certificate)
+		assert.Contains(t, err.Error(), "connection refused")
 		assert.Nil(t, event)
 	})
 }
@@ -194,6 +221,12 @@ func TestHttpClient_RefreshOrganizationCertificate(t *testing.T) {
 		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
 		assert.Nil(t, event)
 	})
+	t.Run("http execution error", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "localhost:9876", Timeout: time.Second}
+		event, err := c.RefreshOrganizationCertificate(test.OrganizationID("1234"))
+		assert.Contains(t, err.Error(), "connection refused")
+		assert.Nil(t, event)
+	})
 }
 
 func TestHttpClient_RegisterEndpoint(t *testing.T) {
@@ -214,6 +247,12 @@ func TestHttpClient_RegisterEndpoint(t *testing.T) {
 
 		event, err := c.RegisterEndpoint(test.OrganizationID("orgId"), "id", "url", "type", "status", nil)
 		assert.EqualError(t, err, "registry returned HTTP 500 (expected: 200), response: ", "error")
+		assert.Nil(t, event)
+	})
+	t.Run("http execution error", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "localhost:9876", Timeout: time.Second}
+		event, err := c.RegisterEndpoint(test.OrganizationID("orgId"), "id", "url", "type", "status", map[string]string{"foo": "bar"})
+		assert.Contains(t, err.Error(), "connection refused")
 		assert.Nil(t, event)
 	})
 }
@@ -268,5 +307,11 @@ func TestHttpClient_EndpointsByOrganizationAndType(t *testing.T) {
 		if len(res) != 1 {
 			t.Errorf("Expected 1 Endpoint in return, got [%d]", len(res))
 		}
+	})
+	t.Run("http execution error", func(t *testing.T) {
+		c := HttpClient{ServerAddress: "localhost:9876", Timeout: time.Second}
+		event, err := c.EndpointsByOrganizationAndType(test.OrganizationID("entity"), nil)
+		assert.Contains(t, err.Error(), "connection refused")
+		assert.Nil(t, event)
 	})
 }

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/generated_test.go
+++ b/api/generated_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/validation.go
+++ b/api/validation.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package api
 
 import "testing"

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/client/client.go
+++ b/client/client.go
@@ -30,13 +30,14 @@ import (
 
 // NewRegistryClient creates a new Local- or RemoteClient for the nuts registry
 func NewRegistryClient() pkg.RegistryClient {
-	registry := pkg.RegistryInstance()
+	return initialize(pkg.RegistryInstance())
+}
 
+func initialize(registry *pkg.Registry) pkg.RegistryClient {
 	if registry.Config.Mode == core.ServerEngineMode {
 		if err := registry.Configure(); err != nil {
 			logrus.Panic(err)
 		}
-
 		return registry
 	} else {
 		return api.HttpClient{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package client
 
 import (

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/nuts-foundation/nuts-registry/api"
+	"github.com/nuts-foundation/nuts-registry/pkg"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInitialize(t *testing.T) {
+	t.Run("server mode", func(t *testing.T) {
+		instance := pkg.RegistryInstance()
+		instance.Config.Mode = core.ServerEngineMode
+		assert.IsType(t, &pkg.Registry{}, initialize(instance))
+	})
+	t.Run("client mode", func(t *testing.T) {
+		instance := pkg.RegistryInstance()
+		instance.Config.Mode = core.ClientEngineMode
+		assert.IsType(t, api.HttpClient{}, initialize(instance))
+	})
+}
+
+func TestNewRegistryClient(t *testing.T) {
+	client := NewRegistryClient()
+	assert.NotNil(t, client)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,5 +3,5 @@ ignore:
   - "test/*"
   - '**/test.go'
   - "mock/*"
-  - "mock.go"
+  - "**/mock.go"
   - "docs/*"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -61,8 +61,9 @@ func NewRegistryEngine() *core.Engine {
 		Routes: func(router core.EchoRouter) {
 			api.RegisterHandlers(router, &api.ApiWrapper{R: r})
 		},
-		Start:    r.Start,
-		Shutdown: r.Shutdown,
+		Start:       r.Start,
+		Shutdown:    r.Shutdown,
+		Diagnostics: r.Diagnostics,
 	}
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package engine
 
 import (

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -6,7 +6,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"github.com/nuts-foundation/nuts-go-test/io"
+	"github.com/spf13/cobra"
 	"net"
+	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -24,6 +26,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	configureIdentity()
 	// Register test instance singleton
 	pkg.NewTestRegistryInstance(io.TestDirectory(t))
 	command := cmd()
@@ -246,4 +249,9 @@ func generateCertificate() map[string]interface{} {
 	certAsJWK, _ := cert.CertificateToJWK(certificate)
 	certAsMap, _ := cert.JwkToMap(certAsJWK)
 	return certAsMap
+}
+
+func configureIdentity() {
+	os.Setenv("NUTS_IDENTITY", test.VendorID("4").String())
+	core.NutsConfig().Load(&cobra.Command{})
 }

--- a/go.mod
+++ b/go.mod
@@ -8,17 +8,22 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.2
+	github.com/jinzhu/gorm v1.9.14 // indirect
+	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/labstack/gommon v0.3.0
 	github.com/lestrrat-go/jwx v0.9.2
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200820094547-b4c9cde032d6
 	github.com/nuts-foundation/nuts-go-core v0.14.1-0.20200730092253-26a9b6830c94
 	github.com/nuts-foundation/nuts-go-test v0.0.0-20200804135944-9e05711330e7
-	github.com/nuts-foundation/nuts-network v0.0.0-20200806071245-5b12ac465a57
+	github.com/nuts-foundation/nuts-network v0.0.0-20200915092706-e18c876fe721
 	github.com/pelletier/go-toml v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
+	google.golang.org/genproto v0.0.0-20200507105951-43844f6eee31 // indirect
+	google.golang.org/grpc v1.29.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/cznic/mathutil v0.0.0-20180504122225-ca4c9f2c1369/go.mod h1:e6NPNENfs
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deepmap/oapi-codegen v1.3.6/go.mod h1:aBozjEveG+33xPiP55Iw/XbVkhtZHEGLq3nxlX0+hfU=
+github.com/deepmap/oapi-codegen v1.3.8/go.mod h1:kmvHN8Gd6to5zLS+P8mhUYJI+Lmn4h7NH00s/5erjd8=
 github.com/deepmap/oapi-codegen v1.3.9 h1:8e3ZfNFzwMDJ5kojta1GGS2+RjzWIThwDWgwe9GqQrE=
 github.com/deepmap/oapi-codegen v1.3.9/go.mod h1:suMvK7+rKlx3+tpa8ByptmvoXbAV70wERKTOGH3hLp0=
 github.com/deepmap/oapi-codegen v1.3.11 h1:Nd3tDQfqgquLmCzyRONHzs5SJEwPPoQcFZxT8MKt1Hs=
@@ -110,6 +112,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
+github.com/getkin/kin-openapi v0.2.0/go.mod h1:V1z9xl9oF5Wt7v32ne4FmiF1alpS4dM6mNzoywPOXlk=
+github.com/getkin/kin-openapi v0.3.0/go.mod h1:W8dhxZgpE84ciM+VIItFqkmZ4eHtuomrdIHtASQIqi0=
 github.com/getkin/kin-openapi v0.13.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -150,6 +154,7 @@ github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -284,12 +289,14 @@ github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo/v4 v4.1.11 h1:z0BZoArY4FqdpUEl+wlHp4hnr/oSR6MTmQmv8OHSoww=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
+github.com/labstack/echo/v4 v4.1.13/go.mod h1:3WZNypykZ3tnqpF2Qb4fPg27XDunFqgP3HGDmCMgv7U=
 github.com/labstack/echo/v4 v4.1.16 h1:8swiwjE5Jkai3RPfZoahp8kjVCRNq+y7Q0hPji2Kz0o=
 github.com/labstack/echo/v4 v4.1.16/go.mod h1:awO+5TzAjvL8XpibdsfXxPgHr+orhtXZJZIQCVjogKI=
 github.com/labstack/echo/v4 v4.1.17 h1:PQIBaRplyRy3OjwILGkPg89JRtH2x5bssi59G2EL3fo=
 github.com/labstack/echo/v4 v4.1.17/go.mod h1:Tn2yRQL/UclUalpb5rPdXDevbkJ+lp/2svdyFBg6CHQ=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/lestrrat-go/jwx v0.9.1/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/lestrrat-go/jwx v0.9.2 h1:1neTPQvRiPRtQpU7QHEEG6dM8A1AFCgi1FGN/2VBucA=
 github.com/lestrrat-go/jwx v0.9.2/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -323,6 +330,7 @@ github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -351,6 +359,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
 github.com/neo4j-drivers/gobolt v1.7.4/go.mod h1:O9AUbip4Dgre+CD3p40dnMD4a4r52QBIfblg5k7CTbE=
 github.com/neo4j/neo4j-go-driver v1.7.4/go.mod h1:aPO0vVr+WnhEJne+FgFjfsjzAnssPFLucHgGZ76Zb/U=
+github.com/nuts-foundation/nuts-crypto v0.13.1 h1:c3B9vrFX7WINToLHUAC7mdjfzahVMqlnjcXWLR7LMKE=
+github.com/nuts-foundation/nuts-crypto v0.13.1/go.mod h1:A+8TA3p+b73Bc1Hx8TFods389I3hWmJ9oXMtS7KE1w0=
 github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200710131507-8f3cf7e71409/go.mod h1:KSWwwrekQjuHMFk/HyckOyMSN134odVHESyDIV2PVig=
 github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200721105241-90e452e194ca h1:whfz54Q1pI5r6gCvJq57FdM9KpDZ+iBwH5xbuIEetYE=
 github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200721105241-90e452e194ca/go.mod h1:Mqfv0hXK3IS2SoOGFQ28vKQt+Ec7o9wONGXXt+uv/Xk=
@@ -366,6 +376,10 @@ github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200806064724-32ed0e791e6a h1:
 github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200806064724-32ed0e791e6a/go.mod h1:H4VJ2zVuktzNSkRlMCQWv9ijSyxB4u6vdPvrXZ+DEWg=
 github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200820094547-b4c9cde032d6 h1:78LfRLb1Vrc2gdDVpFSRlRJQU0hq3yRr9JQ8rPqhH6g=
 github.com/nuts-foundation/nuts-crypto v0.13.2-0.20200820094547-b4c9cde032d6/go.mod h1:VnDO/ILeeFoQxRqyYFzxOFXYpsdPhkmcNIreOjWMnjQ=
+github.com/nuts-foundation/nuts-crypto v0.14.0 h1:gXgZR0QwyBBdutmTercXiFx3foRuLxfmNickm98JX5U=
+github.com/nuts-foundation/nuts-crypto v0.14.0/go.mod h1:CtjEbMFRirswucR5s7353qcIF+QPHVLIsQ6vL4fNVAA=
+github.com/nuts-foundation/nuts-go-core v0.13.0/go.mod h1:YVG736ZUyC0nHRozNUsbLPRnxQouCzoARpswWgPV55g=
+github.com/nuts-foundation/nuts-go-core v0.14.0/go.mod h1:zn4htpIzJ9ap5HYF8l4enNsf75Bq83kK/+B1pd/kflU=
 github.com/nuts-foundation/nuts-go-core v0.14.1-0.20200624131634-75b5f59c0b8e h1:Ums7038f7Y0sOx/MnXIrLwFNbQPwpeGDU6K3feSXlSI=
 github.com/nuts-foundation/nuts-go-core v0.14.1-0.20200624131634-75b5f59c0b8e/go.mod h1:zn4htpIzJ9ap5HYF8l4enNsf75Bq83kK/+B1pd/kflU=
 github.com/nuts-foundation/nuts-go-core v0.14.1-0.20200728125536-8a1b46560e8a h1:N4cQlzSatE6lvPewRHj7NEKA90UPmBJh686axIAIzpE=
@@ -382,6 +396,10 @@ github.com/nuts-foundation/nuts-network v0.0.0-20200804065715-69613fe3ec81 h1:+5
 github.com/nuts-foundation/nuts-network v0.0.0-20200804065715-69613fe3ec81/go.mod h1:hlhoSAQyUiyxTkkjXXnsn7HdKndouuWzBu2U6kyNj58=
 github.com/nuts-foundation/nuts-network v0.0.0-20200806071245-5b12ac465a57 h1:cSYG/Fc0cpp067hq7Vmjh9c0+jNdgbBMgDZqUxBiYXg=
 github.com/nuts-foundation/nuts-network v0.0.0-20200806071245-5b12ac465a57/go.mod h1:cFvJ3CUU7NWmambfZPgh2M7v3RVAUVQsFbtvJMiqJPE=
+github.com/nuts-foundation/nuts-network v0.0.0-20200827071127-79d3ad80ca02 h1:dqBZfNNAC7f8t7BsbXZTn1/arfI+leBd1pHLWue+DHo=
+github.com/nuts-foundation/nuts-network v0.0.0-20200827071127-79d3ad80ca02/go.mod h1:cRT/BBh2nvJacVqSJtcgdAfjxlwnMb3DbajtnQsSiuA=
+github.com/nuts-foundation/nuts-network v0.0.0-20200915092706-e18c876fe721 h1:zgrg73suVnXUm/+PvOqi3m18pnYRsL48Qzl+xrZoSPU=
+github.com/nuts-foundation/nuts-network v0.0.0-20200915092706-e18c876fe721/go.mod h1:cRT/BBh2nvJacVqSJtcgdAfjxlwnMb3DbajtnQsSiuA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -440,6 +458,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -466,6 +485,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
@@ -528,6 +548,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
@@ -636,6 +657,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777 h1:wejkGHRTr38uaKRqECZlsCsJ1/TGxIyFbH32x5zUdu4=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -698,6 +720,7 @@ golang.org/x/tools v0.0.0-20200128002243-345141a36859/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200213224642-88e652f7a869 h1:DPqS0AlgYBVHhG5jnEVScBXXIS+xjgn7O8s1E3sDqxc=
 golang.org/x/tools v0.0.0-20200213224642-88e652f7a869/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -778,6 +801,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/admin.go
+++ b/pkg/admin.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package pkg
 
 import (

--- a/pkg/admin_test.go
+++ b/pkg/admin_test.go
@@ -408,16 +408,6 @@ func TestCreateAndSubmitCSR(t *testing.T) {
 	})
 }
 
-//
-//func TestRegistry_signAsVendor(t *testing.T) {
-//	t.Run("error - unable to create CSR", func(t *testing.T) {
-//		cxt := createTestContext(t)
-//		defer cxt.close()
-//		_, err := cxt.registry.signAsVendor(vendorId, "vendorName", "", []byte{1, 2, 3}, time.Now())
-//		assert.Equal(t, err.Error(), "unable to create CSR for JWS signing: missing domain")
-//	})
-//}
-
 func TestRegistry_signAsOrganization(t *testing.T) {
 	t.Run("error - unable to create CSR", func(t *testing.T) {
 		cxt := createTestContext(t)

--- a/pkg/admin_test.go
+++ b/pkg/admin_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package pkg
 
 import (

--- a/pkg/cert/certificate.go
+++ b/pkg/cert/certificate.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package cert
 
 import (

--- a/pkg/cert/certificate_test.go
+++ b/pkg/cert/certificate_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package cert
 
 import (

--- a/pkg/cert/csr.go
+++ b/pkg/cert/csr.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package cert
 
 import (

--- a/pkg/cert/csr_test.go
+++ b/pkg/cert/csr_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package cert
 
 import (

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/db/memory.go
+++ b/pkg/db/memory.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -141,7 +141,11 @@ func TestMemoryDb_RegisterVendor(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = eventSystem.PublishEvent(registerVendor1)
+		var duplicateVendor = events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{
+			Identifier: test.VendorID("v1"),
+			Name:       "Vendor Uno",
+		}, nil)
+		err = eventSystem.PublishEvent(duplicateVendor)
 		assert.EqualError(t, err, "vendor already registered (id = urn:oid:1.3.6.1.4.1.54851.4:v1)")
 	}))
 }
@@ -226,7 +230,13 @@ func TestMemoryDb_VendorClaim(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = eventSystem.PublishEvent(vendorClaim1)
+		var duplicateOrg = events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{
+			VendorID:       test.VendorID("v1"),
+			OrganizationID: test.OrganizationID("o1"),
+			OrgName:        "Organization Uno",
+			OrgKeys:        nil,
+		}, nil)
+		err = eventSystem.PublishEvent(duplicateOrg)
 		assert.Error(t, err)
 	}))
 }
@@ -373,7 +383,14 @@ func TestMemoryDb_RegisterEndpoint(t *testing.T) {
 		eventSystem.PublishEvent(registerVendor1)
 		eventSystem.PublishEvent(vendorClaim1)
 		eventSystem.PublishEvent(registerEndpoint1)
-		err := eventSystem.PublishEvent(registerEndpoint1)
+		var duplicateEndpoint = events.CreateEvent(domain.RegisterEndpoint, domain.RegisterEndpointEvent{
+			Organization: test.OrganizationID("o1"),
+			URL:          "foo:bar",
+			EndpointType: "simple",
+			Identifier:   "e1",
+			Status:       StatusActive,
+		}, nil)
+		err := eventSystem.PublishEvent(duplicateEndpoint)
 		assert.EqualError(t, err, "endpoint already registered for this organization (id = e1)")
 	}))
 	t.Run("error - unknown organization", withTestContext(func(t *testing.T, eventSystem events.EventSystem, db *MemoryDb) {

--- a/pkg/events/domain/certificates.go
+++ b/pkg/events/domain/certificates.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/certificates_test.go
+++ b/pkg/events/domain/certificates_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/event_register_endpoint.go
+++ b/pkg/events/domain/event_register_endpoint.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/event_register_endpoint_test.go
+++ b/pkg/events/domain/event_register_endpoint_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/event_register_vendor.go
+++ b/pkg/events/domain/event_register_vendor.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/event_register_vendor_test.go
+++ b/pkg/events/domain/event_register_vendor_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/event_vendor_claim.go
+++ b/pkg/events/domain/event_vendor_claim.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/event_vendor_claim_test.go
+++ b/pkg/events/domain/event_vendor_claim_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/types.go
+++ b/pkg/events/domain/types.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/domain/types_test.go
+++ b/pkg/events/domain/types_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package domain
 
 import (

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package events
 
 import (

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -11,6 +11,16 @@ import (
 	"time"
 )
 
+func CreateTestEvent(eventType EventType, payload interface{}, previousEvent Ref, issuedAt time.Time) Event {
+	return &jsonEvent{
+		EventVersion:  currentEventVersion,
+		EventType:     string(eventType),
+		PreviousEvent: previousEvent,
+		EventIssuedAt: issuedAt,
+		EventPayload:  payload,
+	}
+}
+
 type testEvent struct {
 	unmarshalPostProcCalled bool
 }

--- a/pkg/events/files.go
+++ b/pkg/events/files.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/events/files_test.go
+++ b/pkg/events/files_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/events/lookuptable.go
+++ b/pkg/events/lookuptable.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package events
 
 import (

--- a/pkg/events/lookuptable_test.go
+++ b/pkg/events/lookuptable_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package events
 
 import (

--- a/pkg/events/signatures.go
+++ b/pkg/events/signatures.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package events
 
 import (

--- a/pkg/events/signatures_test.go
+++ b/pkg/events/signatures_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package events
 
 import (

--- a/pkg/events/system.go
+++ b/pkg/events/system.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/events/system.go
+++ b/pkg/events/system.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/nuts-crypto/log"
 	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
+	core "github.com/nuts-foundation/nuts-go-core"
 	errors2 "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -65,6 +66,7 @@ type EventSystem interface {
 	PublishEvent(event Event) error
 	LoadAndApplyEvents() error
 	Configure(location string) error
+	Diagnostics() []core.DiagnosticResult
 	EventLookup
 }
 
@@ -106,6 +108,15 @@ func (system *diskEventSystem) Configure(location string) error {
 
 func (system *diskEventSystem) RegisterEventHandler(eventType EventType, handler EventHandler) {
 	system.eventHandlers[eventType] = append(system.eventHandlers[eventType], handler)
+}
+
+func (system *diskEventSystem) Diagnostics() []core.DiagnosticResult {
+	return []core.DiagnosticResult{
+		&core.GenericDiagnosticResult{
+			Title:   "Number of events to be retried",
+			Outcome: fmt.Sprintf("%d", len(system.eventsToBeRetried)),
+		},
+	}
 }
 
 // isEventType checks whether the given type is supported.

--- a/pkg/events/system_test.go
+++ b/pkg/events/system_test.go
@@ -67,6 +67,19 @@ func TestNoEventHandler(t *testing.T) {
 	assert.EqualError(t, err, "no handlers registered for event (type = some-type), handlers are: map[]")
 }
 
+func TestDiagnostics(t *testing.T) {
+	repo, err := test.NewTestRepo(t)
+	if !assert.NoError(t, err) {
+		return
+	}
+	system := NewEventSystem()
+	system.Configure(repo.Directory + "/events")
+	diagnostics := system.Diagnostics()
+	assert.Len(t, diagnostics, 1)
+	assert.Equal(t, "0", diagnostics[0].String())
+	assert.NotEmpty(t, diagnostics[0].Name())
+}
+
 func TestProcessEventsOutOfOrder(t *testing.T) {
 	eventType := EventType("increment")
 	value := 0

--- a/pkg/events/system_test.go
+++ b/pkg/events/system_test.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/events/system_test.go
+++ b/pkg/events/system_test.go
@@ -86,9 +86,11 @@ func TestProcessEventsOutOfOrder(t *testing.T) {
 		return nil
 	})
 	events := make([]Event, 0)
+	var prevEvent Ref
 	for i := 0; i < 100; i++ {
-		event := CreateTestEvent(eventType, i + 1, nil, time.Unix(int64(10000 + i), 0))
+		event := CreateTestEvent(eventType, i + 1, prevEvent, time.Unix(int64(10000 + i), 0))
 		events = append(events, event)
+		prevEvent = event.Ref()
 	}
 	// Sort random order
 	sort.Slice(events, func(i, j int) bool {
@@ -103,7 +105,7 @@ func TestProcessEventsOutOfOrder(t *testing.T) {
 	assert.Empty(t, (system.(*diskEventSystem)).eventsToBeRetried)
 }
 
-func TestLoadEvents(t *testing.T) {
+func TestLoadAndApplyEvents(t *testing.T) {
 	system := NewEventSystem("RegisterVendorEvent", "VendorClaimEvent", "RegisterEndpointEvent")
 	vendorsCreated := 0
 	system.RegisterEventHandler("RegisterVendorEvent", func(e Event, _ EventLookup) error {

--- a/pkg/migrate.go
+++ b/pkg/migrate.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package pkg
 
 import (

--- a/pkg/migrate_test.go
+++ b/pkg/migrate_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package pkg
 
 import (

--- a/pkg/network/ambassador.go
+++ b/pkg/network/ambassador.go
@@ -1,7 +1,8 @@
 package network
 
 import (
-	"github.com/labstack/gommon/log"
+	"bytes"
+	log "github.com/nuts-foundation/nuts-crypto/log"
 	crypto "github.com/nuts-foundation/nuts-crypto/pkg"
 	network "github.com/nuts-foundation/nuts-network/pkg"
 	"github.com/nuts-foundation/nuts-network/pkg/model"
@@ -15,19 +16,24 @@ const documentType = "nuts.registry-event"
 // network and (later on) process notifications of new documents on the network that might be of interest to the registyr.
 type Ambassador interface {
 	RegisterEventHandlers(fn events.EventRegistrar, eventType []events.EventType)
+	// Start instructs the ambassador to start receiving events from the network.
+	Start()
 }
 
 type ambassador struct {
 	networkClient network.NetworkClient
 	cryptoClient  crypto.Client
+	eventSystem   events.EventSystem
 }
 
 // NewAmbassador creates a new Ambassador. Don't forget to call RegisterEventHandlers afterwards.
-func NewAmbassador(networkClient network.NetworkClient, cryptoClient crypto.Client) Ambassador {
-	return &ambassador{
+func NewAmbassador(networkClient network.NetworkClient, cryptoClient crypto.Client, eventSystem events.EventSystem) Ambassador {
+	instance := &ambassador{
 		networkClient: networkClient,
 		cryptoClient:  cryptoClient,
+		eventSystem:   eventSystem,
 	}
+	return instance
 }
 
 // RegisterEventHandlers this event handler which is required for it to actually work.
@@ -40,23 +46,47 @@ func (n *ambassador) RegisterEventHandlers(fn events.EventRegistrar, eventType [
 	}
 }
 
+// Start instructs the ambassador to start receiving events from the network.
+func (n *ambassador) Start() {
+	queue := n.networkClient.Subscribe(documentType)
+	go func() {
+		for {
+			document := queue.Get()
+			if document == nil {
+				return
+			}
+			n.processDocument(document)
+		}
+	}()
+}
+
 func (n *ambassador) sendEventToNetwork(event events.Event) {
 	// For now we just send every event to the network, event other node's events. They're signed so they can't be
 	// edited anyways and it assures the registry shadow copy on the network is populated ASAP.
 	eventData := event.Marshal()
-	hash := model.CalculateDocumentHash(documentType, event.IssuedAt(), eventData)
-	existingDocument, err := n.networkClient.GetDocument(hash)
-	if err != nil {
-		log.Errorf("Error while checking whether document exists on the network (event=%s,hash=%s): %v", event.IssuedAt(), hash, err)
-		return
-	} else if existingDocument != nil && existingDocument.HasContents {
-		log.Debugf("Document already exists on the network (event=%s,hash=%s): %v", event.IssuedAt(), hash, err)
-		return
-	}
 	document, err := n.networkClient.AddDocumentWithContents(event.IssuedAt(), documentType, eventData)
 	if err != nil {
-		log.Errorf("Error registering event on the network (event=%s,hash=%s): %v", event.IssuedAt(), hash, err)
+		log.Logger().Errorf("Error registering event on the network (event=%s): %v", event.IssuedAt(), err)
 		return
 	}
 	logrus.Infof("Event registered on network (event=%s,hash=%s)", event.IssuedAt(), document.Hash)
+}
+
+func (n *ambassador) processDocument(document *model.Document) {
+	log.Logger().Infof("Received event through Nuts Network: %s", document.Hash)
+	reader, err := n.networkClient.GetDocumentContents(document.Hash)
+	if err != nil {
+		log.Logger().Errorf("Unable to retrieve document from Nuts Network (hash=%s): %v", document.Hash, err)
+		return
+	}
+	buf := new(bytes.Buffer)
+	if _, err = buf.ReadFrom(reader); err != nil {
+		log.Logger().Errorf("Unable read document data from Nuts Network (hash=%s): %v", document.Hash, err)
+		return
+	}
+	if event, err := events.EventFromJSON(buf.Bytes()); err != nil {
+		log.Logger().Errorf("Unable parse event from Nuts Network (hash=%s): %v", document.Hash, err)
+	} else {
+		_ = n.eventSystem.ProcessEvent(event)
+	}
 }

--- a/pkg/network/ambassador.go
+++ b/pkg/network/ambassador.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package network
 
 import (

--- a/pkg/network/ambassador_test.go
+++ b/pkg/network/ambassador_test.go
@@ -1,0 +1,53 @@
+package network
+
+import (
+	"github.com/nuts-foundation/nuts-crypto/pkg"
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/nuts-foundation/nuts-go-test/io"
+	pkg2 "github.com/nuts-foundation/nuts-network/pkg"
+	"github.com/nuts-foundation/nuts-registry/pkg/events"
+	"github.com/nuts-foundation/nuts-registry/test"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_ambassador_SendAndReceive(t *testing.T) {
+	os.Setenv("NUTS_IDENTITY", test.VendorID("4").String())
+	core.NutsConfig().Load(&cobra.Command{})
+	testDirectory := io.TestDirectory(t)
+	const eventType = events.EventType("testEvent")
+	var eventsHandled sync.WaitGroup
+	eventsHandled.Add(2)
+	eventSystem := events.NewEventSystem(eventType)
+	eventSystem.RegisterEventHandler(eventType, func(event events.Event, lookup events.EventLookup) error {
+		eventsHandled.Done()
+		return nil
+	})
+	eventSystem.Configure(testDirectory)
+	networkInstance := pkg2.NewTestNetworkInstance(testDirectory)
+	ambassador := NewAmbassador(networkInstance, pkg.NewTestCryptoInstance(testDirectory), eventSystem)
+	ambassador.RegisterEventHandlers(eventSystem.RegisterEventHandler, []events.EventType{eventType})
+	ambassador.Start()
+	// Test that we can send a registry event through the network
+	err := eventSystem.ProcessEvent(events.CreateEvent(eventType, "Hello, rest of Network!", nil))
+	if !assert.NoError(t, err) {
+		return
+	}
+	time.Sleep(500 * time.Millisecond) // Async process, wait for event to be processed
+	documents, err := networkInstance.ListDocuments()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Len(t, documents, 1)
+	// Test that we can receive a registry event through the network
+	event := events.CreateEvent(eventType, "Hello from Network!", nil)
+	_, err = networkInstance.AddDocumentWithContents(time.Now(), documentType, event.Marshal())
+	if !assert.NoError(t, err) {
+		return
+	}
+	eventsHandled.Wait()
+}

--- a/pkg/network/ambassador_test.go
+++ b/pkg/network/ambassador_test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package network
 
 import (

--- a/pkg/network/mock.go
+++ b/pkg/network/mock.go
@@ -44,3 +44,15 @@ func (mr *MockAmbassadorMockRecorder) RegisterEventHandlers(fn, eventType interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEventHandlers", reflect.TypeOf((*MockAmbassador)(nil).RegisterEventHandlers), fn, eventType)
 }
+
+// Start mocks base method
+func (m *MockAmbassador) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start
+func (mr *MockAmbassadorMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockAmbassador)(nil).Start))
+}

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -1,6 +1,6 @@
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -216,7 +216,7 @@ func (r *Registry) Configure() error {
 			r.Db = db.New()
 			r.Db.RegisterEventHandlers(r.EventSystem.RegisterEventHandler)
 			if r.networkAmbassador == nil {
-				r.networkAmbassador = network.NewAmbassador(r.network, r.crypto)
+				r.networkAmbassador = network.NewAmbassador(r.network, r.crypto, r.EventSystem)
 			}
 			r.networkAmbassador.RegisterEventHandlers(r.EventSystem.RegisterEventHandler, domain.GetEventTypes())
 			if err = r.EventSystem.Configure(r.getEventsDir()); err != nil {
@@ -276,6 +276,7 @@ func (r *Registry) Start() error {
 		if err != nil {
 			logrus.Error("Error occurred during registry data verification: ", err)
 		}
+		r.networkAmbassador.Start()
 		switch cm := r.Config.SyncMode; cm {
 		case "fs":
 			return r.startFileSystemWatcher()

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -314,6 +314,10 @@ func (r *Registry) Load() error {
 	return nil
 }
 
+func (r *Registry) Diagnostics() []core.DiagnosticResult {
+	return r.EventSystem.Diagnostics()
+}
+
 func (r *Registry) getEventsDir() string {
 	return r.Config.Datadir + "/events"
 }

--- a/pkg/registry_functional_test.go
+++ b/pkg/registry_functional_test.go
@@ -1,0 +1,73 @@
+// +build !race
+
+/*
+ * Nuts registry
+ * Copyright (C) 2019. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package pkg
+
+import (
+	"github.com/google/uuid"
+	"github.com/nuts-foundation/nuts-go-test/io"
+	"github.com/nuts-foundation/nuts-registry/pkg/events"
+	"github.com/nuts-foundation/nuts-registry/pkg/events/domain"
+	"github.com/nuts-foundation/nuts-registry/pkg/types"
+	"github.com/nuts-foundation/nuts-registry/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+
+// Test_Functional_OutOfOrder_Registrations tests that events that are created in chronological order but processed
+// out of order (which can be the case when received through Nuts Network) are still processed later on.
+func Test_Functional_OutOfOrder_Registrations(t *testing.T) {
+	configureIdleTimeout()
+	registry := NewTestRegistryInstance(io.TestDirectory(t))
+	vendorID := test.VendorID("1234")
+	organizationID := test.OrganizationID("5678")
+	registerVendorEvent := events.CreateEvent(domain.RegisterVendor, domain.RegisterVendorEvent{
+		Identifier: vendorID,
+		Name:       "Awesome Vendor",
+		Domain:     types.HealthcareDomain,
+	}, nil)
+	time.Sleep(1 * time.Millisecond) // Make sure events have incrementing timestamps
+	vendorClaimEvent := events.CreateEvent(domain.VendorClaim, domain.VendorClaimEvent{
+		OrganizationID: organizationID,
+		VendorID:       vendorID,
+		OrgName:        "Awesome Organization",
+		Start:          time.Now(),
+	}, nil)
+	time.Sleep(1 * time.Millisecond) // Make sure events have incrementing timestamps
+	registerEndpointEvent := events.CreateEvent(domain.RegisterEndpoint, domain.RegisterEndpointEvent{
+		Organization: organizationID,
+		URL:          "http://foobar",
+		EndpointType: "test",
+		Identifier:   types.EndpointID(uuid.New().String()),
+		Status:       "active",
+	}, nil)
+
+	err := registry.EventSystem.ProcessEvent(registerEndpointEvent)
+	assert.Error(t, err)
+	err = registry.EventSystem.ProcessEvent(vendorClaimEvent)
+	assert.Error(t, err)
+	err = registry.EventSystem.ProcessEvent(registerVendorEvent)
+	assert.NoError(t, err)
+	endpoints, _ := registry.Db.FindEndpointsByOrganizationAndType(organizationID, nil)
+	assert.Len(t, endpoints, 1)
+}

--- a/pkg/registry_functional_test.go
+++ b/pkg/registry_functional_test.go
@@ -23,12 +23,15 @@ package pkg
 
 import (
 	"github.com/google/uuid"
+	core "github.com/nuts-foundation/nuts-go-core"
 	"github.com/nuts-foundation/nuts-go-test/io"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"github.com/nuts-foundation/nuts-registry/pkg/events/domain"
 	"github.com/nuts-foundation/nuts-registry/pkg/types"
 	"github.com/nuts-foundation/nuts-registry/test"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 	"time"
 )
@@ -37,6 +40,8 @@ import (
 // Test_Functional_OutOfOrder_Registrations tests that events that are created in chronological order but processed
 // out of order (which can be the case when received through Nuts Network) are still processed later on.
 func Test_Functional_OutOfOrder_Registrations(t *testing.T) {
+	os.Setenv("NUTS_IDENTITY", test.VendorID("4").String())
+	core.NutsConfig().Load(&cobra.Command{})
 	configureIdleTimeout()
 	registry := NewTestRegistryInstance(io.TestDirectory(t))
 	vendorID := test.VendorID("1234")

--- a/pkg/registry_functional_test.go
+++ b/pkg/registry_functional_test.go
@@ -2,7 +2,7 @@
 
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -281,6 +281,12 @@ func TestRegistry_EndpointsByOrganizationAndType(t *testing.T) {
 	})
 }
 
+func TestRegistry_Diagnostics(t *testing.T) {
+	registry := createTestContext(t).registry
+	diagnostics := registry.Diagnostics()
+	assert.NotEmpty(t, diagnostics)
+}
+
 func TestRegistry_SearchOrganizations(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/registry_test.go
+++ b/pkg/registry_test.go
@@ -2,7 +2,7 @@
 
 /*
  * Nuts registry
- * Copyright (C) 2019. Nuts community
+ * Copyright (C) 2020. Nuts community
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/pkg/test.go
+++ b/pkg/test.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package pkg
 
 import (

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,3 +1,21 @@
+/*
+ * Nuts registry
+ * Copyright (C) 2020. Nuts community
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 package types
 
 type EndpointID string


### PR DESCRIPTION
Fixes #141 

This PR is two-fold:

1. Support processing registry events received out of order but whose timestamps are chronologically in order. Nuts Network delivers documents in unordered, which can cause problems when processing registry events (e.g. endpoint registration before organization exists). This PR allows failed events to be retried later using a chronologically ordered retry 'queue'.
2. Subscribe to network documents of type **nuts.registry-event** (which indicates a registry event) and process them.