### PR TITLE
add vendorId to db.organisation

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -24,12 +24,13 @@ import (
 	crypto2 "crypto"
 	"crypto/x509"
 	"errors"
+	"time"
+
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
 	core "github.com/nuts-foundation/nuts-go-core"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"github.com/nuts-foundation/nuts-registry/pkg/types"
-	"time"
 )
 
 // StatusActive represents the "active" status
@@ -48,6 +49,7 @@ type Endpoint struct {
 // Organization defines component schema for Organization.
 type Organization struct {
 	Identifier core.PartyID `json:"identifier"`
+	Vendor     core.PartyID `json:"vendor"`
 	Name       string       `json:"name"`
 	// Deprecated: use Keys or helper functions to retrieve the current key in use by the organization
 	PublicKey *string       `json:"publicKey,omitempty"`

--- a/pkg/db/memory.go
+++ b/pkg/db/memory.go
@@ -23,12 +23,13 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
 	core "github.com/nuts-foundation/nuts-go-core"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	"github.com/nuts-foundation/nuts-registry/pkg/events/domain"
 	errors2 "github.com/pkg/errors"
-	"strings"
 )
 
 type MemoryDb struct {
@@ -52,6 +53,7 @@ type endpoint struct {
 func (o org) toDb() Organization {
 	result := Organization{
 		Identifier: o.OrganizationID,
+		Vendor:     o.VendorID,
 		Name:       o.OrgName,
 		Keys:       o.OrgKeys,
 		Endpoints:  o.toDbEndpoints(),

--- a/pkg/db/memory_test.go
+++ b/pkg/db/memory_test.go
@@ -21,6 +21,8 @@ package db
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
 	test2 "github.com/nuts-foundation/nuts-crypto/test"
@@ -28,7 +30,6 @@ import (
 	"github.com/nuts-foundation/nuts-registry/pkg/events/domain"
 	"github.com/nuts-foundation/nuts-registry/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Test data:
@@ -528,5 +529,13 @@ func Test_org_toDb(t *testing.T) {
 		}
 		pubKey, _ := cert.PemToPublicKey([]byte(*publicKey))
 		assert.Equal(t, rsaKey.PublicKey, *pubKey)
+	})
+
+	t.Run("Vendor identifier is copied", func(t *testing.T) {
+		p := test.VendorID("v1")
+		o := org{VendorClaimEvent: domain.VendorClaimEvent{
+			VendorID: p,
+		}}
+		assert.Equal(t, p, o.toDb().Vendor)
 	})
 }


### PR DESCRIPTION
required for nuts-foundation/nuts-auth#97: check if the actor in the bearer token is registered by the vendor that is doing the request.