### PR TITLE
add VendorById tp api/client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -206,7 +206,7 @@ func (apiResource ApiWrapper) VendorById(ctx echo.Context, id string) error {
 	if result == nil {
 		return ctx.JSON(http.StatusNotFound, fmt.Sprintf("Could not find vendor with id %s", vendorID))
 	}
-	return ctx.JSON(http.StatusOK, Vendor{}.fromDB(*result))
+	return ctx.JSON(http.StatusOK, Vendor{}.fromDb(*result))
 }
 
 // EndpointsByOrganisationId is the Api implementation for getting all or certain types of endpoints for an organization

--- a/api/api.go
+++ b/api/api.go
@@ -200,8 +200,9 @@ func (apiResource ApiWrapper) VendorById(ctx echo.Context, id string) error {
 		return nil
 	}
 	result, err := apiResource.R.VendorById(vendorID)
-	if err != nil {
+	if err != nil && !errors.Is(err, pkg.ErrVendorNotFound) {
 		logrus.Errorf("Error getting vendor %s: %v", vendorID, err)
+		return ctx.String(http.StatusInternalServerError, "an internal server error occurred")
 	}
 	if result == nil {
 		return ctx.JSON(http.StatusNotFound, fmt.Sprintf("Could not find vendor with id %s", vendorID))

--- a/api/api.go
+++ b/api/api.go
@@ -25,11 +25,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	core "github.com/nuts-foundation/nuts-go-core"
-	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
+	core "github.com/nuts-foundation/nuts-go-core"
 
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 
@@ -190,6 +191,22 @@ func (apiResource ApiWrapper) OrganizationById(ctx echo.Context, id string) erro
 		return ctx.JSON(http.StatusNotFound, fmt.Sprintf("Could not find organization with id %s", organizationID))
 	}
 	return ctx.JSON(http.StatusOK, Organization{}.fromDb(*result))
+}
+
+// VendorById is the Api implementation for getting a vendor based on its Id.
+func (apiResource ApiWrapper) VendorById(ctx echo.Context, id string) error {
+	vendorID := tryParsePartyID(id, ctx)
+	if vendorID.IsZero() {
+		return nil
+	}
+	result, err := apiResource.R.VendorById(vendorID)
+	if err != nil {
+		logrus.Errorf("Error getting vendor %s: %v", vendorID, err)
+	}
+	if result == nil {
+		return ctx.JSON(http.StatusNotFound, fmt.Sprintf("Could not find vendor with id %s", vendorID))
+	}
+	return ctx.JSON(http.StatusOK, Vendor{}.fromDB(*result))
 }
 
 // EndpointsByOrganisationId is the Api implementation for getting all or certain types of endpoints for an organization

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -67,6 +67,7 @@ type MockDb struct {
 	endpoints      []db.Endpoint
 	organizations  []db.Organization
 	endpointsError error
+	vendorError    error
 }
 
 func (mdb *MockDb) OrganizationsByVendorID(_ core.PartyID) []*db.Organization {
@@ -631,6 +632,9 @@ func TestApiResource_VendorById(t *testing.T) {
 		}
 
 		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+	t.Run("500", func(t *testing.T) {
+		t.Skip("Currently not possible due to in-memory db")
 	})
 	t.Run("400 invalid PartyID", func(t *testing.T) {
 		e, wrapper := initEcho(&MockDb{vendors: []db.Vendor{}})

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -28,12 +28,13 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	core "github.com/nuts-foundation/nuts-go-core"
-	"github.com/nuts-foundation/nuts-registry/pkg/types"
-	"github.com/nuts-foundation/nuts-registry/test"
 	"net/url"
 	"strings"
 	"time"
+
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/nuts-foundation/nuts-registry/pkg/types"
+	"github.com/nuts-foundation/nuts-registry/test"
 
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
@@ -712,7 +713,7 @@ func TestApiResource_VendorClaim(t *testing.T) {
 			b, _ := json.Marshal(Organization{
 				Identifier: Identifier(orgID.String()),
 				Name:       "def",
-				Keys:       &[]JWK{{AdditionalProperties: map[string]interface{}{}}},
+				Keys:       &[]JWK{},
 			})
 
 			req := httptest.NewRequest(echo.POST, "/", bytes.NewReader(b))
@@ -733,7 +734,7 @@ func TestApiResource_VendorClaim(t *testing.T) {
 			b, _ := json.Marshal(Organization{
 				Identifier: Identifier(orgID.String()),
 				Name:       "def",
-				Keys:       &[]JWK{{AdditionalProperties: map[string]interface{}{}}},
+				Keys:       &[]JWK{},
 			})
 
 			req := httptest.NewRequest(echo.POST, "/", bytes.NewReader(b))
@@ -860,13 +861,13 @@ func TestApiResource_RegisterEndpoint(t *testing.T) {
 			orgID := test.OrganizationID("1234")
 			registryClient.EXPECT().RegisterEndpoint(orgID, "", "foo:bar", "fhir", "", map[string]string{"key": "value"})
 
-			props := map[string]string{}
+			props := EndpointProperties{}
 			props["key"] = "value"
 			b, _ := json.Marshal(Endpoint{
 				Identifier:   "",
 				URL:          "foo:bar",
 				EndpointType: "fhir",
-				Properties:   &EndpointProperties{AdditionalProperties: props},
+				Properties:   &props,
 			})
 
 			req := httptest.NewRequest(echo.POST, "/", bytes.NewReader(b))

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -87,11 +87,23 @@ func (o Organization) toDb() db.Organization {
 	return org
 }
 
-func (v Vendor) fromDB(db db.Vendor) Vendor {
+func (v Vendor) fromDb(db db.Vendor) Vendor {
 	id := Identifier(db.Identifier.String())
 	v.Identifier = &id
 	v.Name = db.Name
 	v.Domain = Domain(db.Domain)
+
+	if len(db.Keys) == 0 {
+		return v
+	}
+
+	keys := make([]JWK, len(db.Keys))
+
+	for i, k := range db.Keys {
+		keys[i] = k.(map[string]interface{})
+	}
+
+	v.Keys = &keys
 
 	return v
 }
@@ -105,6 +117,11 @@ func (v Vendor) toDb() db.Vendor {
 		id, _ := core.ParsePartyID(v.Identifier.String())
 		vendor.Identifier = id
 	}
+
+	if v.Keys != nil {
+		vendor.Keys = jwkToMap(*v.Keys)
+	}
+
 	return vendor
 }
 

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -34,14 +34,14 @@ func TestOrganizationConversion(t *testing.T) {
 		o := Organization{}.fromDb(db.Organization{Keys: em})
 
 		assert.Len(t, *o.Keys, 1)
-		assert.Equal(t, "EC", (*o.Keys)[0].AdditionalProperties["kty"].(string))
+		assert.Equal(t, "EC", (*o.Keys)[0]["kty"].(string))
 	})
 
 	t.Run("JWK is converted correctly to DB", func(t *testing.T) {
-		em := []JWK{{AdditionalProperties: map[string]interface{}{"kty": "EC"}}}
+		em := []JWK{{"kty": "EC"}}
 		o := Organization{Keys: &em}.toDb()
 
 		assert.Len(t, o.Keys, 1)
-		assert.Equal(t, "EC", o.Keys[0].(JWK).AdditionalProperties["kty"].(string))
+		assert.Equal(t, "EC", o.Keys[0].(JWK)["kty"].(string))
 	})
 }

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -45,3 +45,23 @@ func TestOrganizationConversion(t *testing.T) {
 		assert.Equal(t, "EC", o.Keys[0].(JWK)["kty"].(string))
 	})
 }
+
+func TestVendorConversion(t *testing.T) {
+	t.Run("JWK is converted correctly from DB", func(t *testing.T) {
+		em := make([]interface{}, 1)
+		em[0] = map[string]interface{}{"kty": "EC"}
+
+		o := Vendor{}.fromDb(db.Vendor{Keys: em})
+
+		assert.Len(t, *o.Keys, 1)
+		assert.Equal(t, "EC", (*o.Keys)[0]["kty"].(string))
+	})
+
+	t.Run("JWK is converted correctly to DB", func(t *testing.T) {
+		em := []JWK{{"kty": "EC"}}
+		o := Vendor{Keys: &em}.toDb()
+
+		assert.Len(t, o.Keys, 1)
+		assert.Equal(t, "EC", o.Keys[0].(JWK)["kty"].(string))
+	})
+}

--- a/api/generated.go
+++ b/api/generated.go
@@ -8,15 +8,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/deepmap/oapi-codegen/pkg/runtime"
-	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/deepmap/oapi-codegen/pkg/runtime"
+	"github.com/labstack/echo/v4"
 )
 
 // CAListWithChain defines model for CAListWithChain.
@@ -31,6 +31,13 @@ type CAListWithChain struct {
 
 // Domain defines model for Domain.
 type Domain string
+
+// List of Domain
+const (
+	Domain_healthcare Domain = "healthcare"
+	Domain_insurance  Domain = "insurance"
+	Domain_personal   Domain = "personal"
+)
 
 // Endpoint defines model for Endpoint.
 type Endpoint struct {
@@ -55,9 +62,7 @@ type Endpoint struct {
 }
 
 // EndpointProperties defines model for EndpointProperties.
-type EndpointProperties struct {
-	AdditionalProperties map[string]string `json:"-"`
-}
+type EndpointProperties map[string]interface{}
 
 // Event defines model for Event.
 type Event struct {
@@ -79,9 +84,7 @@ type Event struct {
 type Identifier string
 
 // JWK defines model for JWK.
-type JWK struct {
-	AdditionalProperties map[string]interface{} `json:"-"`
-}
+type JWK map[string]interface{}
 
 // Organization defines model for Organization.
 type Organization struct {
@@ -132,6 +135,19 @@ type RegisterVendorEvent struct {
 	// the well-known name for the vendor
 	Name    string `json:"name"`
 	OrgKeys *[]JWK `json:"orgKeys,omitempty"`
+}
+
+// Vendor defines model for Vendor.
+type Vendor struct {
+
+	// Domain the entity operates in.
+	Domain Domain `json:"domain"`
+
+	// Generic identifier used for representing BSN, agbcode, etc. It's always constructed as an URN followed by a double colon (:) and then the identifying value of the given URN
+	Identifier *Identifier `json:"identifier,omitempty"`
+
+	// the well-known name for the vendor
+	Name string `json:"name"`
 }
 
 // VendorClaimEvent defines model for VendorClaimEvent.
@@ -195,112 +211,6 @@ type RegisterEndpointJSONRequestBody RegisterEndpointJSONBody
 
 // DeprecatedVendorClaimRequestBody defines body for DeprecatedVendorClaim for application/json ContentType.
 type DeprecatedVendorClaimJSONRequestBody DeprecatedVendorClaimJSONBody
-
-// Getter for additional properties for EndpointProperties. Returns the specified
-// element and whether it was found
-func (a EndpointProperties) Get(fieldName string) (value string, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for EndpointProperties
-func (a *EndpointProperties) Set(fieldName string, value string) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]string)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for EndpointProperties to handle AdditionalProperties
-func (a *EndpointProperties) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]string)
-		for fieldName, fieldBuf := range object {
-			var fieldVal string
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for EndpointProperties to handle AdditionalProperties
-func (a EndpointProperties) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
-
-// Getter for additional properties for JWK. Returns the specified
-// element and whether it was found
-func (a JWK) Get(fieldName string) (value interface{}, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for JWK
-func (a *JWK) Set(fieldName string, value interface{}) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]interface{})
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for JWK to handle AdditionalProperties
-func (a *JWK) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]interface{})
-		for fieldName, fieldBuf := range object {
-			var fieldVal interface{}
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for JWK to handle AdditionalProperties
-func (a JWK) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -403,6 +313,9 @@ type ClientInterface interface {
 
 	// SearchOrganizations request
 	SearchOrganizations(ctx context.Context, params *SearchOrganizationsParams) (*http.Response, error)
+
+	// VendorById request
+	VendorById(ctx context.Context, id string) (*http.Response, error)
 
 	// DeprecatedVendorClaim request  with any body
 	DeprecatedVendorClaimWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
@@ -565,6 +478,21 @@ func (c *Client) RefreshOrganizationCertificate(ctx context.Context, id string) 
 
 func (c *Client) SearchOrganizations(ctx context.Context, params *SearchOrganizationsParams) (*http.Response, error) {
 	req, err := NewSearchOrganizationsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VendorById(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewVendorByIdRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -1011,6 +939,40 @@ func NewSearchOrganizationsRequest(server string, params *SearchOrganizationsPar
 	return req, nil
 }
 
+// NewVendorByIdRequest generates requests for VendorById
+func NewVendorByIdRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/api/vendor/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewDeprecatedVendorClaimRequest calls the generic DeprecatedVendorClaim builder with application/json body
 func NewDeprecatedVendorClaimRequest(server string, id string, body DeprecatedVendorClaimJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1112,7 +1074,52 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-type verifyResponse struct {
+// ClientWithResponsesInterface is the interface specification for the client with responses above.
+type ClientWithResponsesInterface interface {
+	// Verify request
+	VerifyWithResponse(ctx context.Context, params *VerifyParams) (*VerifyResponse, error)
+
+	// EndpointsByOrganisationId request
+	EndpointsByOrganisationIdWithResponse(ctx context.Context, params *EndpointsByOrganisationIdParams) (*EndpointsByOrganisationIdResponse, error)
+
+	// MTLSCAs request
+	MTLSCAsWithResponse(ctx context.Context) (*MTLSCAsResponse, error)
+
+	// MTLSCertificates request
+	MTLSCertificatesWithResponse(ctx context.Context) (*MTLSCertificatesResponse, error)
+
+	// VendorClaim request  with any body
+	VendorClaimWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*VendorClaimResponse, error)
+
+	VendorClaimWithResponse(ctx context.Context, body VendorClaimJSONRequestBody) (*VendorClaimResponse, error)
+
+	// OrganizationById request
+	OrganizationByIdWithResponse(ctx context.Context, id string) (*OrganizationByIdResponse, error)
+
+	// RegisterEndpoint request  with any body
+	RegisterEndpointWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*RegisterEndpointResponse, error)
+
+	RegisterEndpointWithResponse(ctx context.Context, id string, body RegisterEndpointJSONRequestBody) (*RegisterEndpointResponse, error)
+
+	// RefreshOrganizationCertificate request
+	RefreshOrganizationCertificateWithResponse(ctx context.Context, id string) (*RefreshOrganizationCertificateResponse, error)
+
+	// SearchOrganizations request
+	SearchOrganizationsWithResponse(ctx context.Context, params *SearchOrganizationsParams) (*SearchOrganizationsResponse, error)
+
+	// VendorById request
+	VendorByIdWithResponse(ctx context.Context, id string) (*VendorByIdResponse, error)
+
+	// DeprecatedVendorClaim request  with any body
+	DeprecatedVendorClaimWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*DeprecatedVendorClaimResponse, error)
+
+	DeprecatedVendorClaimWithResponse(ctx context.Context, id string, body DeprecatedVendorClaimJSONRequestBody) (*DeprecatedVendorClaimResponse, error)
+
+	// RegisterVendor request  with any body
+	RegisterVendorWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*RegisterVendorResponse, error)
+}
+
+type VerifyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -1126,7 +1133,7 @@ type verifyResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r verifyResponse) Status() string {
+func (r VerifyResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1134,20 +1141,20 @@ func (r verifyResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r verifyResponse) StatusCode() int {
+func (r VerifyResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type endpointsByOrganisationIdResponse struct {
+type EndpointsByOrganisationIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r endpointsByOrganisationIdResponse) Status() string {
+func (r EndpointsByOrganisationIdResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1155,21 +1162,21 @@ func (r endpointsByOrganisationIdResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r endpointsByOrganisationIdResponse) StatusCode() int {
+func (r EndpointsByOrganisationIdResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type mTLSCAsResponse struct {
+type MTLSCAsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *CAListWithChain
 }
 
 // Status returns HTTPResponse.Status
-func (r mTLSCAsResponse) Status() string {
+func (r MTLSCAsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1177,21 +1184,21 @@ func (r mTLSCAsResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r mTLSCAsResponse) StatusCode() int {
+func (r MTLSCAsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type mTLSCertificatesResponse struct {
+type MTLSCertificatesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]string
 }
 
 // Status returns HTTPResponse.Status
-func (r mTLSCertificatesResponse) Status() string {
+func (r MTLSCertificatesResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1199,21 +1206,21 @@ func (r mTLSCertificatesResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r mTLSCertificatesResponse) StatusCode() int {
+func (r MTLSCertificatesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type vendorClaimResponse struct {
+type VendorClaimResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Event
 }
 
 // Status returns HTTPResponse.Status
-func (r vendorClaimResponse) Status() string {
+func (r VendorClaimResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1221,20 +1228,21 @@ func (r vendorClaimResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r vendorClaimResponse) StatusCode() int {
+func (r VendorClaimResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type organizationByIdResponse struct {
+type OrganizationByIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON200      *Organization
 }
 
 // Status returns HTTPResponse.Status
-func (r organizationByIdResponse) Status() string {
+func (r OrganizationByIdResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1242,43 +1250,21 @@ func (r organizationByIdResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r organizationByIdResponse) StatusCode() int {
+func (r OrganizationByIdResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type registerEndpointResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Event
-}
-
-// Status returns HTTPResponse.Status
-func (r registerEndpointResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r registerEndpointResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type refreshOrganizationCertificateResponse struct {
+type RegisterEndpointResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Event
 }
 
 // Status returns HTTPResponse.Status
-func (r refreshOrganizationCertificateResponse) Status() string {
+func (r RegisterEndpointResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1286,42 +1272,21 @@ func (r refreshOrganizationCertificateResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r refreshOrganizationCertificateResponse) StatusCode() int {
+func (r RegisterEndpointResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type searchOrganizationsResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-}
-
-// Status returns HTTPResponse.Status
-func (r searchOrganizationsResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r searchOrganizationsResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type deprecatedVendorClaimResponse struct {
+type RefreshOrganizationCertificateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *Event
 }
 
 // Status returns HTTPResponse.Status
-func (r deprecatedVendorClaimResponse) Status() string {
+func (r RefreshOrganizationCertificateResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1329,21 +1294,20 @@ func (r deprecatedVendorClaimResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r deprecatedVendorClaimResponse) StatusCode() int {
+func (r RefreshOrganizationCertificateResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type registerVendorResponse struct {
+type SearchOrganizationsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Event
 }
 
 // Status returns HTTPResponse.Status
-func (r registerVendorResponse) Status() string {
+func (r SearchOrganizationsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1351,7 +1315,73 @@ func (r registerVendorResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r registerVendorResponse) StatusCode() int {
+func (r SearchOrganizationsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type VendorByIdResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Vendor
+}
+
+// Status returns HTTPResponse.Status
+func (r VendorByIdResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VendorByIdResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeprecatedVendorClaimResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Event
+}
+
+// Status returns HTTPResponse.Status
+func (r DeprecatedVendorClaimResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeprecatedVendorClaimResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RegisterVendorResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Event
+}
+
+// Status returns HTTPResponse.Status
+func (r RegisterVendorResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RegisterVendorResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1359,7 +1389,7 @@ func (r registerVendorResponse) StatusCode() int {
 }
 
 // VerifyWithResponse request returning *VerifyResponse
-func (c *ClientWithResponses) VerifyWithResponse(ctx context.Context, params *VerifyParams) (*verifyResponse, error) {
+func (c *ClientWithResponses) VerifyWithResponse(ctx context.Context, params *VerifyParams) (*VerifyResponse, error) {
 	rsp, err := c.Verify(ctx, params)
 	if err != nil {
 		return nil, err
@@ -1368,7 +1398,7 @@ func (c *ClientWithResponses) VerifyWithResponse(ctx context.Context, params *Ve
 }
 
 // EndpointsByOrganisationIdWithResponse request returning *EndpointsByOrganisationIdResponse
-func (c *ClientWithResponses) EndpointsByOrganisationIdWithResponse(ctx context.Context, params *EndpointsByOrganisationIdParams) (*endpointsByOrganisationIdResponse, error) {
+func (c *ClientWithResponses) EndpointsByOrganisationIdWithResponse(ctx context.Context, params *EndpointsByOrganisationIdParams) (*EndpointsByOrganisationIdResponse, error) {
 	rsp, err := c.EndpointsByOrganisationId(ctx, params)
 	if err != nil {
 		return nil, err
@@ -1377,7 +1407,7 @@ func (c *ClientWithResponses) EndpointsByOrganisationIdWithResponse(ctx context.
 }
 
 // MTLSCAsWithResponse request returning *MTLSCAsResponse
-func (c *ClientWithResponses) MTLSCAsWithResponse(ctx context.Context) (*mTLSCAsResponse, error) {
+func (c *ClientWithResponses) MTLSCAsWithResponse(ctx context.Context) (*MTLSCAsResponse, error) {
 	rsp, err := c.MTLSCAs(ctx)
 	if err != nil {
 		return nil, err
@@ -1386,7 +1416,7 @@ func (c *ClientWithResponses) MTLSCAsWithResponse(ctx context.Context) (*mTLSCAs
 }
 
 // MTLSCertificatesWithResponse request returning *MTLSCertificatesResponse
-func (c *ClientWithResponses) MTLSCertificatesWithResponse(ctx context.Context) (*mTLSCertificatesResponse, error) {
+func (c *ClientWithResponses) MTLSCertificatesWithResponse(ctx context.Context) (*MTLSCertificatesResponse, error) {
 	rsp, err := c.MTLSCertificates(ctx)
 	if err != nil {
 		return nil, err
@@ -1395,7 +1425,7 @@ func (c *ClientWithResponses) MTLSCertificatesWithResponse(ctx context.Context) 
 }
 
 // VendorClaimWithBodyWithResponse request with arbitrary body returning *VendorClaimResponse
-func (c *ClientWithResponses) VendorClaimWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*vendorClaimResponse, error) {
+func (c *ClientWithResponses) VendorClaimWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*VendorClaimResponse, error) {
 	rsp, err := c.VendorClaimWithBody(ctx, contentType, body)
 	if err != nil {
 		return nil, err
@@ -1403,7 +1433,7 @@ func (c *ClientWithResponses) VendorClaimWithBodyWithResponse(ctx context.Contex
 	return ParseVendorClaimResponse(rsp)
 }
 
-func (c *ClientWithResponses) VendorClaimWithResponse(ctx context.Context, body VendorClaimJSONRequestBody) (*vendorClaimResponse, error) {
+func (c *ClientWithResponses) VendorClaimWithResponse(ctx context.Context, body VendorClaimJSONRequestBody) (*VendorClaimResponse, error) {
 	rsp, err := c.VendorClaim(ctx, body)
 	if err != nil {
 		return nil, err
@@ -1412,7 +1442,7 @@ func (c *ClientWithResponses) VendorClaimWithResponse(ctx context.Context, body 
 }
 
 // OrganizationByIdWithResponse request returning *OrganizationByIdResponse
-func (c *ClientWithResponses) OrganizationByIdWithResponse(ctx context.Context, id string) (*organizationByIdResponse, error) {
+func (c *ClientWithResponses) OrganizationByIdWithResponse(ctx context.Context, id string) (*OrganizationByIdResponse, error) {
 	rsp, err := c.OrganizationById(ctx, id)
 	if err != nil {
 		return nil, err
@@ -1421,7 +1451,7 @@ func (c *ClientWithResponses) OrganizationByIdWithResponse(ctx context.Context, 
 }
 
 // RegisterEndpointWithBodyWithResponse request with arbitrary body returning *RegisterEndpointResponse
-func (c *ClientWithResponses) RegisterEndpointWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*registerEndpointResponse, error) {
+func (c *ClientWithResponses) RegisterEndpointWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*RegisterEndpointResponse, error) {
 	rsp, err := c.RegisterEndpointWithBody(ctx, id, contentType, body)
 	if err != nil {
 		return nil, err
@@ -1429,7 +1459,7 @@ func (c *ClientWithResponses) RegisterEndpointWithBodyWithResponse(ctx context.C
 	return ParseRegisterEndpointResponse(rsp)
 }
 
-func (c *ClientWithResponses) RegisterEndpointWithResponse(ctx context.Context, id string, body RegisterEndpointJSONRequestBody) (*registerEndpointResponse, error) {
+func (c *ClientWithResponses) RegisterEndpointWithResponse(ctx context.Context, id string, body RegisterEndpointJSONRequestBody) (*RegisterEndpointResponse, error) {
 	rsp, err := c.RegisterEndpoint(ctx, id, body)
 	if err != nil {
 		return nil, err
@@ -1438,7 +1468,7 @@ func (c *ClientWithResponses) RegisterEndpointWithResponse(ctx context.Context, 
 }
 
 // RefreshOrganizationCertificateWithResponse request returning *RefreshOrganizationCertificateResponse
-func (c *ClientWithResponses) RefreshOrganizationCertificateWithResponse(ctx context.Context, id string) (*refreshOrganizationCertificateResponse, error) {
+func (c *ClientWithResponses) RefreshOrganizationCertificateWithResponse(ctx context.Context, id string) (*RefreshOrganizationCertificateResponse, error) {
 	rsp, err := c.RefreshOrganizationCertificate(ctx, id)
 	if err != nil {
 		return nil, err
@@ -1447,7 +1477,7 @@ func (c *ClientWithResponses) RefreshOrganizationCertificateWithResponse(ctx con
 }
 
 // SearchOrganizationsWithResponse request returning *SearchOrganizationsResponse
-func (c *ClientWithResponses) SearchOrganizationsWithResponse(ctx context.Context, params *SearchOrganizationsParams) (*searchOrganizationsResponse, error) {
+func (c *ClientWithResponses) SearchOrganizationsWithResponse(ctx context.Context, params *SearchOrganizationsParams) (*SearchOrganizationsResponse, error) {
 	rsp, err := c.SearchOrganizations(ctx, params)
 	if err != nil {
 		return nil, err
@@ -1455,8 +1485,17 @@ func (c *ClientWithResponses) SearchOrganizationsWithResponse(ctx context.Contex
 	return ParseSearchOrganizationsResponse(rsp)
 }
 
+// VendorByIdWithResponse request returning *VendorByIdResponse
+func (c *ClientWithResponses) VendorByIdWithResponse(ctx context.Context, id string) (*VendorByIdResponse, error) {
+	rsp, err := c.VendorById(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVendorByIdResponse(rsp)
+}
+
 // DeprecatedVendorClaimWithBodyWithResponse request with arbitrary body returning *DeprecatedVendorClaimResponse
-func (c *ClientWithResponses) DeprecatedVendorClaimWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*deprecatedVendorClaimResponse, error) {
+func (c *ClientWithResponses) DeprecatedVendorClaimWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*DeprecatedVendorClaimResponse, error) {
 	rsp, err := c.DeprecatedVendorClaimWithBody(ctx, id, contentType, body)
 	if err != nil {
 		return nil, err
@@ -1464,7 +1503,7 @@ func (c *ClientWithResponses) DeprecatedVendorClaimWithBodyWithResponse(ctx cont
 	return ParseDeprecatedVendorClaimResponse(rsp)
 }
 
-func (c *ClientWithResponses) DeprecatedVendorClaimWithResponse(ctx context.Context, id string, body DeprecatedVendorClaimJSONRequestBody) (*deprecatedVendorClaimResponse, error) {
+func (c *ClientWithResponses) DeprecatedVendorClaimWithResponse(ctx context.Context, id string, body DeprecatedVendorClaimJSONRequestBody) (*DeprecatedVendorClaimResponse, error) {
 	rsp, err := c.DeprecatedVendorClaim(ctx, id, body)
 	if err != nil {
 		return nil, err
@@ -1473,7 +1512,7 @@ func (c *ClientWithResponses) DeprecatedVendorClaimWithResponse(ctx context.Cont
 }
 
 // RegisterVendorWithBodyWithResponse request with arbitrary body returning *RegisterVendorResponse
-func (c *ClientWithResponses) RegisterVendorWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*registerVendorResponse, error) {
+func (c *ClientWithResponses) RegisterVendorWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*RegisterVendorResponse, error) {
 	rsp, err := c.RegisterVendorWithBody(ctx, contentType, body)
 	if err != nil {
 		return nil, err
@@ -1482,14 +1521,14 @@ func (c *ClientWithResponses) RegisterVendorWithBodyWithResponse(ctx context.Con
 }
 
 // ParseVerifyResponse parses an HTTP response from a VerifyWithResponse call
-func ParseVerifyResponse(rsp *http.Response) (*verifyResponse, error) {
+func ParseVerifyResponse(rsp *http.Response) (*VerifyResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &verifyResponse{
+	response := &VerifyResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1515,14 +1554,14 @@ func ParseVerifyResponse(rsp *http.Response) (*verifyResponse, error) {
 }
 
 // ParseEndpointsByOrganisationIdResponse parses an HTTP response from a EndpointsByOrganisationIdWithResponse call
-func ParseEndpointsByOrganisationIdResponse(rsp *http.Response) (*endpointsByOrganisationIdResponse, error) {
+func ParseEndpointsByOrganisationIdResponse(rsp *http.Response) (*EndpointsByOrganisationIdResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &endpointsByOrganisationIdResponse{
+	response := &EndpointsByOrganisationIdResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1534,14 +1573,14 @@ func ParseEndpointsByOrganisationIdResponse(rsp *http.Response) (*endpointsByOrg
 }
 
 // ParseMTLSCAsResponse parses an HTTP response from a MTLSCAsWithResponse call
-func ParseMTLSCAsResponse(rsp *http.Response) (*mTLSCAsResponse, error) {
+func ParseMTLSCAsResponse(rsp *http.Response) (*MTLSCAsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &mTLSCAsResponse{
+	response := &MTLSCAsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1563,14 +1602,14 @@ func ParseMTLSCAsResponse(rsp *http.Response) (*mTLSCAsResponse, error) {
 }
 
 // ParseMTLSCertificatesResponse parses an HTTP response from a MTLSCertificatesWithResponse call
-func ParseMTLSCertificatesResponse(rsp *http.Response) (*mTLSCertificatesResponse, error) {
+func ParseMTLSCertificatesResponse(rsp *http.Response) (*MTLSCertificatesResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &mTLSCertificatesResponse{
+	response := &MTLSCertificatesResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1592,14 +1631,14 @@ func ParseMTLSCertificatesResponse(rsp *http.Response) (*mTLSCertificatesRespons
 }
 
 // ParseVendorClaimResponse parses an HTTP response from a VendorClaimWithResponse call
-func ParseVendorClaimResponse(rsp *http.Response) (*vendorClaimResponse, error) {
+func ParseVendorClaimResponse(rsp *http.Response) (*VendorClaimResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &vendorClaimResponse{
+	response := &VendorClaimResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1618,33 +1657,40 @@ func ParseVendorClaimResponse(rsp *http.Response) (*vendorClaimResponse, error) 
 }
 
 // ParseOrganizationByIdResponse parses an HTTP response from a OrganizationByIdWithResponse call
-func ParseOrganizationByIdResponse(rsp *http.Response) (*organizationByIdResponse, error) {
+func ParseOrganizationByIdResponse(rsp *http.Response) (*OrganizationByIdResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &organizationByIdResponse{
+	response := &OrganizationByIdResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Organization
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	}
 
 	return response, nil
 }
 
 // ParseRegisterEndpointResponse parses an HTTP response from a RegisterEndpointWithResponse call
-func ParseRegisterEndpointResponse(rsp *http.Response) (*registerEndpointResponse, error) {
+func ParseRegisterEndpointResponse(rsp *http.Response) (*RegisterEndpointResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &registerEndpointResponse{
+	response := &RegisterEndpointResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1663,14 +1709,14 @@ func ParseRegisterEndpointResponse(rsp *http.Response) (*registerEndpointRespons
 }
 
 // ParseRefreshOrganizationCertificateResponse parses an HTTP response from a RefreshOrganizationCertificateWithResponse call
-func ParseRefreshOrganizationCertificateResponse(rsp *http.Response) (*refreshOrganizationCertificateResponse, error) {
+func ParseRefreshOrganizationCertificateResponse(rsp *http.Response) (*RefreshOrganizationCertificateResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &refreshOrganizationCertificateResponse{
+	response := &RefreshOrganizationCertificateResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1689,14 +1735,14 @@ func ParseRefreshOrganizationCertificateResponse(rsp *http.Response) (*refreshOr
 }
 
 // ParseSearchOrganizationsResponse parses an HTTP response from a SearchOrganizationsWithResponse call
-func ParseSearchOrganizationsResponse(rsp *http.Response) (*searchOrganizationsResponse, error) {
+func ParseSearchOrganizationsResponse(rsp *http.Response) (*SearchOrganizationsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &searchOrganizationsResponse{
+	response := &SearchOrganizationsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1707,15 +1753,41 @@ func ParseSearchOrganizationsResponse(rsp *http.Response) (*searchOrganizationsR
 	return response, nil
 }
 
-// ParseDeprecatedVendorClaimResponse parses an HTTP response from a DeprecatedVendorClaimWithResponse call
-func ParseDeprecatedVendorClaimResponse(rsp *http.Response) (*deprecatedVendorClaimResponse, error) {
+// ParseVendorByIdResponse parses an HTTP response from a VendorByIdWithResponse call
+func ParseVendorByIdResponse(rsp *http.Response) (*VendorByIdResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &deprecatedVendorClaimResponse{
+	response := &VendorByIdResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Vendor
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeprecatedVendorClaimResponse parses an HTTP response from a DeprecatedVendorClaimWithResponse call
+func ParseDeprecatedVendorClaimResponse(rsp *http.Response) (*DeprecatedVendorClaimResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeprecatedVendorClaimResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1734,14 +1806,14 @@ func ParseDeprecatedVendorClaimResponse(rsp *http.Response) (*deprecatedVendorCl
 }
 
 // ParseRegisterVendorResponse parses an HTTP response from a RegisterVendorWithResponse call
-func ParseRegisterVendorResponse(rsp *http.Response) (*registerVendorResponse, error) {
+func ParseRegisterVendorResponse(rsp *http.Response) (*RegisterVendorResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &registerVendorResponse{
+	response := &RegisterVendorResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1788,6 +1860,9 @@ type ServerInterface interface {
 	// Search for organizations
 	// (GET /api/organizations)
 	SearchOrganizations(ctx echo.Context, params SearchOrganizationsParams) error
+	// Get vendor by id
+	// (GET /api/vendor/{id})
+	VendorById(ctx echo.Context, id string) error
 	// Claim an organization for a vendor (registers an organization under a vendor in the registry).
 	// (POST /api/vendor/{id}/claim)
 	DeprecatedVendorClaim(ctx echo.Context, id string) error
@@ -1951,6 +2026,22 @@ func (w *ServerInterfaceWrapper) SearchOrganizations(ctx echo.Context) error {
 	return err
 }
 
+// VendorById converts echo context to params.
+func (w *ServerInterfaceWrapper) VendorById(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameter("simple", false, "id", ctx.Param("id"), &id)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.VendorById(ctx, id)
+	return err
+}
+
 // DeprecatedVendorClaim converts echo context to params.
 func (w *ServerInterfaceWrapper) DeprecatedVendorClaim(ctx echo.Context) error {
 	var err error
@@ -2007,6 +2098,7 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 	router.POST("/api/organization/:id/endpoints", wrapper.RegisterEndpoint)
 	router.POST("/api/organization/:id/refresh-cert", wrapper.RefreshOrganizationCertificate)
 	router.GET("/api/organizations", wrapper.SearchOrganizations)
+	router.GET("/api/vendor/:id", wrapper.VendorById)
 	router.POST("/api/vendor/:id/claim", wrapper.DeprecatedVendorClaim)
 	router.POST("/api/vendors", wrapper.RegisterVendor)
 

--- a/api/generated.go
+++ b/api/generated.go
@@ -145,6 +145,7 @@ type Vendor struct {
 
 	// Generic identifier used for representing BSN, agbcode, etc. It's always constructed as an URN followed by a double colon (:) and then the identifying value of the given URN
 	Identifier *Identifier `json:"identifier,omitempty"`
+	Keys       *[]JWK      `json:"keys,omitempty"`
 
 	// the well-known name for the vendor
 	Name string `json:"name"`

--- a/api/generated_test.go
+++ b/api/generated_test.go
@@ -91,6 +91,12 @@ func (e RestInterfaceStub) OrganizationById(ctx echo.Context, id string) error {
 	return err
 }
 
+func (e RestInterfaceStub) VendorById(ctx echo.Context, id string) error {
+	var err error
+
+	return err
+}
+
 func (e RestInterfaceStub) MTLSCAs(ctx echo.Context) error {
 	var err error
 

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -60,7 +60,7 @@ func TestOrganization_validate(t *testing.T) {
 		Name       string
 		PublicKey  *string
 	}
-	keys := &[]JWK{{AdditionalProperties: map[string]interface{}{}}}
+	keys := &[]JWK{}
 	tests := []struct {
 		name    string
 		fields  fields

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -415,6 +415,10 @@ components:
           example: Medicare Software for People B.V.
         domain:
           $ref: "#/components/schemas/Domain"
+        keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/JWK"
     Organization:
       required:
         - name

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -28,6 +28,33 @@ paths:
                 $ref: '#/components/schemas/Event'
         '400':
           description: "incorrect PEM file"
+  /api/vendor/{id}:
+    get:
+      summary: "Get vendor by id"
+      operationId: vendorById
+      tags:
+        - vendors
+      parameters:
+        - name: id
+          in: path
+          description: "URL encoded identifier"
+          required: true
+          example: "urn:oid:2.16.840.1.113883.2.4.6.1:00000007"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK response with vendor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vendor'
+        '404':
+          description: Unknown organization
+          content:
+            text/plain:
+              schema:
+                type: string
   /api/vendor/{id}/claim:
     post:
       deprecated: true
@@ -158,9 +185,9 @@ paths:
             type: string
       responses:
         '200':
-          description: OK response with list of valid organizations, list may be empty
+          description: OK response with organization
           content:
-            text/plain:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Organization'
         '404':
@@ -380,6 +407,8 @@ components:
         - name
         - domain
       properties:
+        identifier:
+          $ref: "#/components/schemas/Identifier"
         name:
           type: string
           description: the well-known name for the vendor

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -49,6 +49,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Vendor'
+        '400':
+          description: "incorrect vendor id"
+          content:
+            text/plain:
+              schema:
+                type: string
         '404':
           description: Unknown organization
           content:

--- a/docs/_static/nuts-registry.yaml
+++ b/docs/_static/nuts-registry.yaml
@@ -56,7 +56,7 @@ paths:
               schema:
                 type: string
         '404':
-          description: Unknown organization
+          description: Unknown vendor
           content:
             text/plain:
               schema:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/labstack/gommon v0.3.0
 	github.com/lestrrat-go/jwx v0.9.2
-	github.com/nuts-foundation/nuts-crypto v0.15.0
+	github.com/nuts-foundation/nuts-crypto v0.15.1-0.20201009062953-f3b551897b53
 	github.com/nuts-foundation/nuts-go-core v0.15.0
 	github.com/nuts-foundation/nuts-go-test v0.15.0
 	github.com/nuts-foundation/nuts-network v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ github.com/nuts-foundation/nuts-crypto v0.14.0 h1:gXgZR0QwyBBdutmTercXiFx3foRuLx
 github.com/nuts-foundation/nuts-crypto v0.14.0/go.mod h1:CtjEbMFRirswucR5s7353qcIF+QPHVLIsQ6vL4fNVAA=
 github.com/nuts-foundation/nuts-crypto v0.15.0 h1:C3E2NSXD1t3G1pPBOWtIr/V2r+y638Q7twOq+qPXb1w=
 github.com/nuts-foundation/nuts-crypto v0.15.0/go.mod h1:xz02sBTLi8w38xAGCpEV1jxhSd8r0/SviELIS3Ety0s=
+github.com/nuts-foundation/nuts-crypto v0.15.1-0.20201009062953-f3b551897b53 h1:U8a2fC786JKywZSblMtowQIlPvJ2dEbQopjTsdtk1hw=
+github.com/nuts-foundation/nuts-crypto v0.15.1-0.20201009062953-f3b551897b53/go.mod h1:8Q6c33DldilQbUzw8UEeL6bwCxTGSxxRlrTMF9BntGg=
 github.com/nuts-foundation/nuts-go-core v0.13.0/go.mod h1:YVG736ZUyC0nHRozNUsbLPRnxQouCzoARpswWgPV55g=
 github.com/nuts-foundation/nuts-go-core v0.14.0/go.mod h1:zn4htpIzJ9ap5HYF8l4enNsf75Bq83kK/+B1pd/kflU=
 github.com/nuts-foundation/nuts-go-core v0.14.1-0.20200624131634-75b5f59c0b8e h1:Ums7038f7Y0sOx/MnXIrLwFNbQPwpeGDU6K3feSXlSI=

--- a/mock/mock_client.go
+++ b/mock/mock_client.go
@@ -7,7 +7,7 @@ package mock
 import (
 	x509 "crypto/x509"
 	gomock "github.com/golang/mock/gomock"
-	core "github.com/nuts-foundation/nuts-go-core"
+	nuts_go_core "github.com/nuts-foundation/nuts-go-core"
 	db "github.com/nuts-foundation/nuts-registry/pkg/db"
 	events "github.com/nuts-foundation/nuts-registry/pkg/events"
 	reflect "reflect"
@@ -37,7 +37,7 @@ func (m *MockRegistryClient) EXPECT() *MockRegistryClientMockRecorder {
 }
 
 // EndpointsByOrganizationAndType mocks base method
-func (m *MockRegistryClient) EndpointsByOrganizationAndType(organizationIdentifier core.PartyID, endpointType *string) ([]db.Endpoint, error) {
+func (m *MockRegistryClient) EndpointsByOrganizationAndType(organizationIdentifier nuts_go_core.PartyID, endpointType *string) ([]db.Endpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EndpointsByOrganizationAndType", organizationIdentifier, endpointType)
 	ret0, _ := ret[0].([]db.Endpoint)
@@ -67,7 +67,7 @@ func (mr *MockRegistryClientMockRecorder) SearchOrganizations(query interface{})
 }
 
 // OrganizationById mocks base method
-func (m *MockRegistryClient) OrganizationById(id core.PartyID) (*db.Organization, error) {
+func (m *MockRegistryClient) OrganizationById(id nuts_go_core.PartyID) (*db.Organization, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OrganizationById", id)
 	ret0, _ := ret[0].(*db.Organization)
@@ -97,7 +97,7 @@ func (mr *MockRegistryClientMockRecorder) ReverseLookup(name interface{}) *gomoc
 }
 
 // RegisterEndpoint mocks base method
-func (m *MockRegistryClient) RegisterEndpoint(organizationID core.PartyID, id, url, endpointType, status string, properties map[string]string) (events.Event, error) {
+func (m *MockRegistryClient) RegisterEndpoint(organizationID nuts_go_core.PartyID, id, url, endpointType, status string, properties map[string]string) (events.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterEndpoint", organizationID, id, url, endpointType, status, properties)
 	ret0, _ := ret[0].(events.Event)
@@ -112,7 +112,7 @@ func (mr *MockRegistryClientMockRecorder) RegisterEndpoint(organizationID, id, u
 }
 
 // VendorClaim mocks base method
-func (m *MockRegistryClient) VendorClaim(orgID core.PartyID, orgName string, orgKeys []interface{}) (events.Event, error) {
+func (m *MockRegistryClient) VendorClaim(orgID nuts_go_core.PartyID, orgName string, orgKeys []interface{}) (events.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VendorClaim", orgID, orgName, orgKeys)
 	ret0, _ := ret[0].(events.Event)
@@ -142,7 +142,7 @@ func (mr *MockRegistryClientMockRecorder) RegisterVendor(certificate interface{}
 }
 
 // RefreshOrganizationCertificate mocks base method
-func (m *MockRegistryClient) RefreshOrganizationCertificate(organizationID core.PartyID) (events.Event, error) {
+func (m *MockRegistryClient) RefreshOrganizationCertificate(organizationID nuts_go_core.PartyID) (events.Event, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshOrganizationCertificate", organizationID)
 	ret0, _ := ret[0].(events.Event)
@@ -184,4 +184,19 @@ func (m *MockRegistryClient) VendorCAs() [][]*x509.Certificate {
 func (mr *MockRegistryClientMockRecorder) VendorCAs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VendorCAs", reflect.TypeOf((*MockRegistryClient)(nil).VendorCAs))
+}
+
+// VendorById mocks base method
+func (m *MockRegistryClient) VendorById(vID nuts_go_core.PartyID) (*db.Vendor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VendorById", vID)
+	ret0, _ := ret[0].(*db.Vendor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VendorById indicates an expected call of VendorById
+func (mr *MockRegistryClientMockRecorder) VendorById(vID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VendorById", reflect.TypeOf((*MockRegistryClient)(nil).VendorById), vID)
 }

--- a/pkg/events/domain/certificates.go
+++ b/pkg/events/domain/certificates.go
@@ -21,12 +21,13 @@ package domain
 import (
 	"crypto/x509"
 	"fmt"
+	"time"
+
 	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
 	cert2 "github.com/nuts-foundation/nuts-registry/pkg/cert"
 	"github.com/nuts-foundation/nuts-registry/pkg/events"
 	errors2 "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 type certificateEventHandler struct {
@@ -66,6 +67,10 @@ func (t certificateEventHandler) verify(certificate *x509.Certificate, moment ti
 	}
 	// We're not supporting multiple chains
 	return chains[0], nil
+}
+
+func (t certificateEventHandler) VerifiedChain(certificate *x509.Certificate, moment time.Time) ([][]*x509.Certificate, error) {
+	return certificate.Verify(x509.VerifyOptions{Roots: t.trustStore.Pool(), CurrentTime: moment})
 }
 
 func (t *certificateEventHandler) handleEvent(event events.Event, _ events.EventLookup) error {

--- a/pkg/events/domain/certificates.go
+++ b/pkg/events/domain/certificates.go
@@ -69,6 +69,8 @@ func (t certificateEventHandler) verify(certificate *x509.Certificate, moment ti
 	return chains[0], nil
 }
 
+// VerifiedChain verifies the given certificate against the trustStore and returns all the chains that could verify the certificate.
+// The func does not allow for a truststore with intermediates!
 func (t certificateEventHandler) VerifiedChain(certificate *x509.Certificate, moment time.Time) ([][]*x509.Certificate, error) {
 	return certificate.Verify(x509.VerifyOptions{Roots: t.trustStore.Pool(), CurrentTime: moment})
 }

--- a/pkg/events/domain/certificates_test.go
+++ b/pkg/events/domain/certificates_test.go
@@ -24,9 +24,10 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
-	"github.com/nuts-foundation/nuts-registry/pkg/types"
 	"testing"
 	"time"
+
+	"github.com/nuts-foundation/nuts-registry/pkg/types"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
@@ -203,6 +204,10 @@ func (n memoryTrustStore) AddCertificate(certificate *x509.Certificate) error {
 
 func (n memoryTrustStore) Verify(c *x509.Certificate, t time.Time) error {
 	return errors.New("irrelevant func")
+}
+
+func (t memoryTrustStore) VerifiedChain(certificate *x509.Certificate, moment time.Time) ([][]*x509.Certificate, error) {
+	return nil, errors.New("irrelevant func")
 }
 
 func (n memoryTrustStore) RegisterEventHandlers(func(events.EventType, events.EventHandler)) {

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -119,7 +119,7 @@ type RegistryClient interface {
 	// VendorCAs returns all registered vendors as list of chains, PEM encoded. The first entry in a chain will be the leaf and the last one the root.
 	VendorCAs() [][]*x509.Certificate
 
-	// VendorById find a vendor by it's ID
+	// VendorById finds a vendor by its ID. When not found it returns an ErrVendorNotFound error and a nil result.
 	VendorById(vID core.PartyID) (*db.Vendor, error)
 }
 

--- a/test/cert.go
+++ b/test/cert.go
@@ -7,9 +7,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"github.com/nuts-foundation/nuts-crypto/test"
 	"math/big"
 	"time"
+
+	"github.com/nuts-foundation/nuts-crypto/test"
 
 	"github.com/lestrrat-go/jwx/jws"
 	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
@@ -103,4 +104,8 @@ type noopCertificateVerifier struct{}
 
 func (n noopCertificateVerifier) Verify(certificate *x509.Certificate, t time.Time) error {
 	return nil
+}
+
+func (n noopCertificateVerifier) VerifiedChain(certificate *x509.Certificate, t time.Time) ([][]*x509.Certificate, error) {
+	return nil, nil
 }


### PR DESCRIPTION
also needed for nuts-foundation/nuts-auth#97
The generated.go has also been generated with a newer oapic-codegen version removing the ugly nested `additionalProperties`