### PR TITLE
Fix nilptr deref when v0 events are received through network

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -214,6 +214,20 @@ func EventFromJSON(data []byte) (Event, error) {
 	return &e, nil
 }
 
+// EventFromJSONWithIssuedAt functions exactly as EventFromJSON but allows the caller to set issuedAt if it's not
+// present in the event which is the case for v0 events. If it's present, the supplied issuedAt is ignored.
+func EventFromJSONWithIssuedAt(data []byte, issuedAt time.Time) (Event, error) {
+	if event, err := EventFromJSON(data); err != nil {
+		return nil, err
+	} else {
+		jEvent := event.(*jsonEvent)
+		if jEvent.IssuedAt().IsZero() {
+			jEvent.EventIssuedAt = issuedAt
+		}
+		return jEvent, nil
+	}
+}
+
 func validateEvent(evt jsonEvent) error {
 	if evt.EventType == "" {
 		return ErrMissingEventType

--- a/pkg/network/ambassador.go
+++ b/pkg/network/ambassador.go
@@ -102,9 +102,11 @@ func (n *ambassador) processDocument(document *model.Document) {
 		log.Logger().Errorf("Unable read document data from Nuts Network (hash=%s): %v", document.Hash, err)
 		return
 	}
-	if event, err := events.EventFromJSON(buf.Bytes()); err != nil {
+	if event, err := events.EventFromJSONWithIssuedAt(buf.Bytes(), document.Timestamp); err != nil {
 		log.Logger().Errorf("Unable parse event from Nuts Network (hash=%s): %v", document.Hash, err)
 	} else {
-		_ = n.eventSystem.ProcessEvent(event)
+		if err = n.eventSystem.ProcessEvent(event); err != nil {
+			log.Logger().Warnf("Error while processing event from Nuts Network (hash=%s): %v", document.Hash, err)
+		}
 	}
 }


### PR DESCRIPTION
Registry v0 events don't have the `issuedAt` field. When loading from disk this is solved by taking the timestamp from the filename as event timestamp (`issuedAt`), but this doesn't work when events are received over Nuts Network. In that case `issuedAt` stays `0` which causes sorting problems when events are received out-of-order because they're sorted on `issuedAt`. This in turn can lead to a nil pointer dereference because a previous event (`prev` field) might not have been processed although it should have, because sorting the events made sure previous events are processed first.

This can be fixed quite easily by using the document timestamp as event `issuedAt`, because document timestamp is filled using `issuedAt` on the sending side.

TODO: Not entirely sure why the second commit is need, need to find out.